### PR TITLE
Fix CLI download for quoted resource names

### DIFF
--- a/data-gov/tools/cli/ui/commands.rs
+++ b/data-gov/tools/cli/ui/commands.rs
@@ -65,17 +65,15 @@ pub fn parse_command_args(s: &str) -> Vec<String> {
     args
 }
 
-impl FromStr for ReplCommand {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts = parse_command_args(s);
-
+impl ReplCommand {
+    pub fn from_parts(parts: &[String]) -> Result<Self, String> {
         if parts.is_empty() {
             return Err("Empty command".to_string());
         }
 
-        match parts[0].to_lowercase().as_str() {
+        let command = parts[0].to_lowercase();
+
+        match command.as_str() {
             "search" | "s" => {
                 if parts.len() < 2 {
                     return Err("Usage: search <query> [limit]".to_string());
@@ -136,6 +134,15 @@ impl FromStr for ReplCommand {
             "quit" | "exit" | "q" => Ok(ReplCommand::Quit),
             _ => Err(format!("Unknown command: {}", parts[0])),
         }
+    }
+}
+
+impl FromStr for ReplCommand {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = parse_command_args(s);
+        ReplCommand::from_parts(&parts)
     }
 }
 

--- a/data-gov/tools/cli/ui/mod.rs
+++ b/data-gov/tools/cli/ui/mod.rs
@@ -8,7 +8,6 @@ mod reporter;
 
 use clap::{Arg, ArgMatches, Command};
 use std::path::PathBuf;
-use std::str::FromStr;
 use std::sync::{Arc, OnceLock};
 use tokio::runtime::Runtime;
 
@@ -227,13 +226,13 @@ fn run_cli_mode(
         .unwrap_or_default()
         .collect();
 
-    // Build command string
-    let mut cmd_parts = vec![command];
-    cmd_parts.extend(args.iter().map(|s| s.as_str()));
-    let full_command = cmd_parts.join(" ");
+    // Build argument list for parsing without losing whitespace information
+    let mut cmd_parts: Vec<String> = Vec::with_capacity(1 + args.len());
+    cmd_parts.push(command.to_string());
+    cmd_parts.extend(args.iter().map(|s| (*s).clone()));
 
     // Parse the command
-    let repl_command = match ReplCommand::from_str(&full_command) {
+    let repl_command = match ReplCommand::from_parts(&cmd_parts) {
         Ok(cmd) => cmd,
         Err(e) => {
             eprintln!("{} {}", color_red_bold("Error:"), e);


### PR DESCRIPTION
Fixes CLI parsing issue when trying to download with named resources. This should work now with the CLI:

```
data-gov download electric-vehicle-population-data "Comma Separated Values File"
```
