### PR TITLE
Test coverage: MCP dispatch routing and download_resources concurrency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]

--- a/data-gov-mcp-server/Cargo.toml
+++ b/data-gov-mcp-server/Cargo.toml
@@ -23,3 +23,6 @@ tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 futures = "0.3"
 data-gov = "0.4.0"
 data-gov-ckan = "0.4.0"
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -1,0 +1,385 @@
+//! Routing tests for [`DataGovMcpServer::dispatch`].
+//!
+//! Verifies the three routing contracts:
+//!
+//! 1. `tools/call` unwraps its nested method name and wraps the result in a
+//!    `ToolResponse` envelope.
+//! 2. A direct call to a registered tool method is also wrapped in a
+//!    `ToolResponse`.
+//! 3. Non-tool methods (`initialize`, `tools/list`) return raw JSON with no
+//!    envelope.
+//!
+//! Plus error-variant contracts for unknown methods and missing params.
+
+use std::sync::Arc;
+
+use data_gov::{DataGovClient, DataGovConfig, OperatingMode};
+use data_gov_ckan::{CkanClient, Configuration as CkanConfiguration};
+use serde_json::{Value, json};
+use wiremock::matchers::{method as wm_method, path as wm_path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::server::DataGovMcpServer;
+use crate::types::ServerError;
+
+/// Build a `DataGovMcpServer` whose internal clients both point at the given
+/// mock URL. Callers mount `Mock`s on the same server before exercising a
+/// dispatch path.
+fn test_server(mock_uri: &str) -> DataGovMcpServer {
+    let ckan_config = Arc::new(CkanConfiguration {
+        base_path: mock_uri.to_string(),
+        user_agent: Some("test/1.0".to_string()),
+        ..Default::default()
+    });
+    let ckan = CkanClient::new(ckan_config);
+
+    let data_gov_config = DataGovConfig::default()
+        .with_base_url(mock_uri)
+        .with_mode(OperatingMode::CommandLine)
+        .with_user_agent("test/1.0");
+    let data_gov = DataGovClient::with_config(data_gov_config).expect("build data_gov");
+
+    DataGovMcpServer {
+        data_gov,
+        ckan,
+        portal_base_url: mock_uri.to_string(),
+    }
+}
+
+/// Extract the inner JSON payload from a `ToolResponse`-shaped value.
+///
+/// The server wraps tool results as `{ content: [{type:"text",...}, {type:"json", json: ...}] }`.
+/// Tests that assert on the wrapped payload use this to reach the inner JSON.
+fn tool_response_json(value: &Value) -> &Value {
+    let content = value
+        .get("content")
+        .and_then(Value::as_array)
+        .expect("ToolResponse must have content array");
+    let json_item = content
+        .iter()
+        .find(|item| item.get("type").and_then(Value::as_str) == Some("json"))
+        .expect("ToolResponse must contain a json item");
+    json_item
+        .get("json")
+        .expect("json item must have inner 'json' field")
+}
+
+// ---------------------------------------------------------------------------
+// tools/list — not a tool itself, returns raw descriptor list
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_tools_list_returns_raw_descriptor_array() {
+    let mock = MockServer::start().await;
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch("tools/list", None)
+        .await
+        .expect("tools/list should succeed with no params");
+
+    // Non-tool methods must not be wrapped in a ToolResponse envelope.
+    assert!(
+        result.get("content").is_none(),
+        "tools/list result must not be wrapped in a ToolResponse"
+    );
+
+    let tools = result
+        .get("tools")
+        .and_then(Value::as_array)
+        .expect("tools/list must return a `tools` array");
+    assert!(
+        !tools.is_empty(),
+        "tools/list must return at least one tool"
+    );
+
+    // Every entry must have the descriptor fields clients rely on.
+    for tool in tools {
+        assert!(tool.get("name").is_some(), "tool missing name: {tool}");
+        assert!(
+            tool.get("description").is_some(),
+            "tool missing description"
+        );
+        assert!(
+            tool.get("inputSchema").is_some(),
+            "tool missing inputSchema"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// tools/call — unwrap, dispatch, wrap
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_tools_call_unwraps_and_wraps_response() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/action/package_search"))
+        .and(query_param("q", "climate"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "help": "", "success": true,
+            "result": { "count": 1, "results": [
+                {"name": "ds-1", "title": "DS1", "id": "00000000-0000-0000-0000-000000000001"}
+            ]}
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch(
+            "tools/call",
+            Some(json!({
+                "name": "data_gov_search",
+                "arguments": { "query": "climate" }
+            })),
+        )
+        .await
+        .expect("tools/call should succeed");
+
+    // Must be wrapped: the outer value has `content`, the inner JSON has `count`.
+    let inner = tool_response_json(&result);
+    assert_eq!(inner.get("count").and_then(Value::as_i64), Some(1));
+}
+
+#[tokio::test]
+async fn dispatch_tools_call_unknown_tool_returns_invalid_method() {
+    let mock = MockServer::start().await;
+    let server = test_server(&mock.uri());
+
+    let err = server
+        .dispatch(
+            "tools/call",
+            Some(json!({ "name": "not_a_real_tool", "arguments": {} })),
+        )
+        .await
+        .expect_err("unknown tool must fail");
+
+    match err {
+        ServerError::InvalidMethod(name) => {
+            assert_eq!(name, "not_a_real_tool");
+        }
+        other => panic!("expected InvalidMethod, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_tools_call_missing_params_returns_invalid_params() {
+    let mock = MockServer::start().await;
+    let server = test_server(&mock.uri());
+
+    let err = server
+        .dispatch("tools/call", None)
+        .await
+        .expect_err("tools/call without params must fail");
+
+    assert!(matches!(err, ServerError::InvalidParams(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Direct tool-method calls are also wrapped
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_direct_tool_method_wraps_response() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/action/package_show"))
+        .and(query_param("id", "my-dataset"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "help": "", "success": true,
+            "result": {
+                "name": "my-dataset",
+                "title": "My Dataset",
+                "id": "00000000-0000-0000-0000-000000000001"
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch("data_gov.dataset", Some(json!({ "id": "my-dataset" })))
+        .await
+        .expect("direct data_gov.dataset call should succeed");
+
+    let inner = tool_response_json(&result);
+    assert_eq!(
+        inner.get("name").and_then(Value::as_str),
+        Some("my-dataset"),
+        "wrapped payload should carry the mocked dataset name"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Unknown methods
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_unknown_method_returns_invalid_method() {
+    let mock = MockServer::start().await;
+    let server = test_server(&mock.uri());
+
+    let err = server
+        .dispatch("not.a.real.method", Some(json!({})))
+        .await
+        .expect_err("unknown method must fail");
+
+    match err {
+        ServerError::InvalidMethod(name) => assert_eq!(name, "not.a.real.method"),
+        other => panic!("expected InvalidMethod, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Non-tool method: initialize
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_initialize_returns_raw_response() {
+    let mock = MockServer::start().await;
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch(
+            "initialize",
+            Some(json!({
+                "clientInfo": { "name": "test-client", "version": "0.0.0" }
+            })),
+        )
+        .await
+        .expect("initialize should succeed");
+
+    assert!(
+        result.get("content").is_none(),
+        "initialize is not a tool — must not be wrapped"
+    );
+    assert!(
+        result.get("serverInfo").is_some() || result.get("protocolVersion").is_some(),
+        "initialize result should carry server metadata, got: {result}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Representative routing to upstream clients
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_ckan_package_search_routes_to_ckan_client() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/action/package_search"))
+        .and(query_param("q", "routing-probe"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "help": "", "success": true,
+            "result": { "count": 7, "results": [] }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch(
+            "ckan.packageSearch",
+            Some(json!({ "query": "routing-probe" })),
+        )
+        .await
+        .expect("ckan.packageSearch should succeed");
+
+    let inner = tool_response_json(&result);
+    assert_eq!(inner.get("count").and_then(Value::as_i64), Some(7));
+}
+
+#[tokio::test]
+async fn dispatch_data_gov_search_attaches_summaries() {
+    // data_gov.search wraps raw package_search and post-processes results into
+    // a `summaries` array. Verifies the handler, not just the router.
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/action/package_search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "help": "", "success": true,
+            "result": {
+                "count": 1,
+                "results": [{
+                    "name": "summary-probe",
+                    "title": "Summary Probe",
+                    "id": "00000000-0000-0000-0000-000000000042"
+                }]
+            }
+        })))
+        .expect(1)
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let result = server
+        .dispatch("data_gov.search", Some(json!({ "query": "probe" })))
+        .await
+        .expect("data_gov.search should succeed");
+
+    let inner = tool_response_json(&result);
+    let summaries = inner
+        .get("summaries")
+        .and_then(Value::as_array)
+        .expect("data_gov.search must produce a summaries array");
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(
+        summaries[0].get("name").and_then(Value::as_str),
+        Some("summary-probe")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Security: path traversal in downloadResources is caught by the handler,
+// not just by the resolve_output_dir helper.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn dispatch_download_resources_rejects_parent_traversal_in_output_dir() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/action/package_show"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "help": "", "success": true,
+            "result": {
+                "name": "some-dataset",
+                "title": "Some Dataset",
+                "id": "00000000-0000-0000-0000-000000000001",
+                "resources": [{
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "url": "http://localhost:1/file.csv",
+                    "format": "CSV",
+                    "name": "file"
+                }]
+            }
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let err = server
+        .dispatch(
+            "data_gov.downloadResources",
+            Some(json!({
+                "datasetId": "some-dataset",
+                "outputDir": "../../etc"
+            })),
+        )
+        .await
+        .expect_err("output_dir with '..' must be rejected");
+
+    match err {
+        ServerError::InvalidParams(msg) => assert!(msg.contains("..")),
+        other => panic!("expected InvalidParams, got {other:?}"),
+    }
+}

--- a/data-gov-mcp-server/src/main.rs
+++ b/data-gov-mcp-server/src/main.rs
@@ -3,6 +3,9 @@ mod server;
 mod tools;
 mod types;
 
+#[cfg(test)]
+mod dispatch_tests;
+
 use server::DataGovMcpServer;
 use tracing_subscriber::{EnvFilter, fmt};
 

--- a/data-gov/tests/download_tests.rs
+++ b/data-gov/tests/download_tests.rs
@@ -1,0 +1,311 @@
+//! Concurrency and partial-failure tests for [`DataGovClient::download_resources`].
+//!
+//! Each test constructs a `DataGovClient` pointed at a `wiremock` server and
+//! supplies a slice of [`Resource`] records whose URLs target the mock. Tests
+//! assert on caller-observable behavior:
+//!
+//! - Return-vector length and ordering match the input
+//! - Partial failures surface as per-resource `Err` without short-circuiting
+//! - Filenames for resources with identical names are disambiguated by index
+//! - The `max_concurrent_downloads` limit is actually enforced
+
+use std::time::{Duration, Instant};
+
+use data_gov::ckan::models::Resource;
+use data_gov::{DataGovClient, DataGovConfig, DataGovError, OperatingMode};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Build a client configured for predictable test behavior.
+fn test_client(download_dir: std::path::PathBuf, max_concurrent: usize) -> DataGovClient {
+    let config = DataGovConfig::default()
+        .with_mode(OperatingMode::Interactive)
+        .with_download_dir(download_dir)
+        .with_max_concurrent_downloads(max_concurrent)
+        .with_download_timeout(10);
+    DataGovClient::with_config(config).expect("test client must build")
+}
+
+/// Create a Resource whose `url` points at the given mock path.
+fn mock_resource(mock_uri: &str, file_path: &str, name: &str, format: &str) -> Resource {
+    Resource {
+        name: Some(name.to_string()),
+        format: Some(format.to_string()),
+        url: Some(format!("{mock_uri}{file_path}")),
+        ..Default::default()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Boundary: empty and single-element input
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_with_empty_slice_returns_empty_vec() {
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    let results = client.download_resources(&[], None).await;
+
+    assert!(
+        results.is_empty(),
+        "empty input must produce empty output, got {} items",
+        results.len()
+    );
+}
+
+#[tokio::test]
+async fn download_resources_with_single_resource_returns_single_result() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/files/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"hello".to_vec()))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    let resources = vec![mock_resource(&server.uri(), "/files/one.csv", "one", "CSV")];
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+
+    assert_eq!(results.len(), 1, "one input must produce one result");
+    let path = results.into_iter().next().unwrap().expect("should succeed");
+    assert!(path.exists(), "downloaded file must exist at {path:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Happy path: all succeed, results line up one-to-one
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_returns_one_result_per_input_in_order() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/files/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"payload".to_vec()))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    let resources = vec![
+        mock_resource(&server.uri(), "/files/a.csv", "a", "CSV"),
+        mock_resource(&server.uri(), "/files/b.csv", "b", "CSV"),
+        mock_resource(&server.uri(), "/files/c.csv", "c", "CSV"),
+    ];
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+
+    assert_eq!(results.len(), 3, "result count must match input count");
+    for (i, r) in results.iter().enumerate() {
+        assert!(r.is_ok(), "resource {i} should have succeeded: {r:?}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Partial failure: a resource with no URL must not short-circuit the batch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_with_mixed_url_and_no_url_returns_mixed_results() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/files/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"payload".to_vec()))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    let resources = vec![
+        mock_resource(&server.uri(), "/files/ok1.csv", "ok1", "CSV"),
+        Resource {
+            name: Some("no-url".to_string()),
+            format: Some("CSV".to_string()),
+            url: None,
+            ..Default::default()
+        },
+        mock_resource(&server.uri(), "/files/ok2.csv", "ok2", "CSV"),
+    ];
+
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+
+    assert_eq!(results.len(), 3);
+    assert!(results[0].is_ok(), "first resource must succeed");
+    match &results[1] {
+        Err(DataGovError::ResourceNotFound { message }) => {
+            assert!(
+                message.contains("no URL") || message.contains("URL"),
+                "error message should explain missing URL, got: {message}"
+            );
+        }
+        other => panic!("expected ResourceNotFound, got {other:?}"),
+    }
+    assert!(results[2].is_ok(), "third resource must still succeed");
+}
+
+// ---------------------------------------------------------------------------
+// Partial failure: per-resource HTTP errors surface without aborting the batch
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_propagates_per_resource_http_errors() {
+    let server = MockServer::start().await;
+
+    // /good/* returns 200; /bad/* returns 500
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/good/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"ok".to_vec()))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/bad/.*"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    let resources = vec![
+        mock_resource(&server.uri(), "/good/a.csv", "a", "CSV"),
+        mock_resource(&server.uri(), "/bad/b.csv", "b", "CSV"),
+        mock_resource(&server.uri(), "/good/c.csv", "c", "CSV"),
+    ];
+
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+
+    assert_eq!(results.len(), 3);
+    assert!(results[0].is_ok(), "good resource must succeed");
+    match &results[1] {
+        Err(DataGovError::DownloadError { message }) => {
+            assert!(
+                message.contains("500"),
+                "error must mention HTTP status, got: {message}"
+            );
+        }
+        other => panic!("expected DownloadError with 500, got {other:?}"),
+    }
+    assert!(results[2].is_ok(), "third resource must not be affected");
+}
+
+// ---------------------------------------------------------------------------
+// Filename disambiguation: duplicate names must not overwrite each other
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_disambiguates_duplicate_filenames_by_index() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/same/.*"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"content".to_vec()))
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 3);
+
+    // Three resources with the same name + format — filenames would collide
+    // without index insertion.
+    let resources = vec![
+        mock_resource(&server.uri(), "/same/1.csv", "report", "CSV"),
+        mock_resource(&server.uri(), "/same/2.csv", "report", "CSV"),
+        mock_resource(&server.uri(), "/same/3.csv", "report", "CSV"),
+    ];
+
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+
+    let paths: Vec<_> = results
+        .into_iter()
+        .map(|r| r.expect("all downloads must succeed"))
+        .collect();
+
+    // All three paths must be distinct, otherwise one download overwrote another.
+    assert_eq!(paths.len(), 3);
+    assert_ne!(paths[0], paths[1]);
+    assert_ne!(paths[1], paths[2]);
+    assert_ne!(paths[0], paths[2]);
+
+    for (i, p) in paths.iter().enumerate() {
+        assert!(p.exists(), "path {i} ({p:?}) must exist on disk");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency cap is enforced: a small max_concurrent_downloads with many
+// slow responses must serialize into batches.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn download_resources_honors_max_concurrent_downloads_cap() {
+    let server = MockServer::start().await;
+    // Each response is delayed ~150ms. With max_concurrent=2 and 4 resources,
+    // the wall-clock total must be at least ~300ms (two batches) — far above
+    // the unlimited-parallel lower bound of ~150ms.
+    let per_request_delay = Duration::from_millis(150);
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/slow/.*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_bytes(b"data".to_vec())
+                .set_delay(per_request_delay),
+        )
+        .mount(&server)
+        .await;
+
+    let tmp = TempDir::new().expect("tempdir");
+    let client = test_client(tmp.path().to_path_buf(), 2);
+
+    let resources: Vec<Resource> = (0..4)
+        .map(|i| {
+            mock_resource(
+                &server.uri(),
+                &format!("/slow/{i}.csv"),
+                &format!("res-{i}"),
+                "CSV",
+            )
+        })
+        .collect();
+
+    let start = Instant::now();
+    let results = client
+        .download_resources(&resources, Some(tmp.path()))
+        .await;
+    let elapsed = start.elapsed();
+
+    for r in &results {
+        assert!(r.is_ok(), "every download must succeed: {r:?}");
+    }
+
+    // Lower bound: two sequential batches of 2 = ~2x the per-request delay,
+    // minus a safety margin for scheduling. Use 1.5x to stay robust.
+    let min_expected = per_request_delay.mul_f32(1.5);
+    assert!(
+        elapsed >= min_expected,
+        "with max_concurrent=2 and 4 slow requests, elapsed must be >= {min_expected:?} \
+         (proves concurrency is bounded), got {elapsed:?}"
+    );
+
+    // Upper bound: well under full serialization (4x delay). Allows generous
+    // headroom for CI jitter while still catching a regression that forces
+    // serial execution.
+    let max_expected = per_request_delay.mul_f32(3.5);
+    assert!(
+        elapsed < max_expected,
+        "elapsed must be < {max_expected:?} (proves downloads aren't fully serial), \
+         got {elapsed:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fills the two test gaps deferred from #18.

- **MCP dispatch routing** (closes #19): 10 new tests in \`data-gov-mcp-server/src/dispatch_tests.rs\` verifying \`DataGovMcpServer::dispatch\` end-to-end — \`tools/call\` unwrap+wrap, direct tool-method wrapping, non-tool raw responses, \`InvalidMethod\`/\`InvalidParams\` error paths, \`tools/list\` descriptor shape, and representative routing to both data-gov and ckan clients. Also asserts \`downloadResources\` rejects \`..\` in \`outputDir\` at the handler boundary (not only in the extracted helper).
- **download_resources concurrency** (closes #20): 7 new tests in \`data-gov/tests/download_tests.rs\` verifying empty/single/batch happy paths, partial failures that don't short-circuit (missing URL + HTTP 500 mixed with successes), filename disambiguation by index, and a timing-bounded assertion that \`max_concurrent_downloads\` is actually enforced.

Also: \`wiremock\` added as a dev-dep to \`data-gov-mcp-server\`. All new tests are offline and deterministic.

Closes #19
Closes #20

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo test --lib --all-features\` (29 passed)
- [x] \`cargo test --doc --all-features\` (7 passed, 4 ignored)
- [x] \`cargo test -p data-gov-ckan --test unit_tests\` (23 passed)
- [x] \`cargo test -p data-gov --test client_tests\` (11 passed)
- [x] \`cargo test -p data-gov --test download_tests\` (7 passed — new)
- [x] \`cargo test -p data-gov-mcp-server\` (55 passed — 10 new under \`dispatch_tests::\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)