### PR TITLE
Fix four MCP server bugs from smoke testing (#26 #27 #28 #30)

### DIFF
--- a/.github/instructions/target-info.instructions.md
+++ b/.github/instructions/target-info.instructions.md
@@ -111,20 +111,29 @@ maintenance mode (bugfixes and security patches).
 
 ## MCP server (`data-gov-mcp-server`)
 
-JSON-RPC 2.0 over stdin/stdout. Tools currently exposed:
+JSON-RPC 2.0 over stdin/stdout. Tools are invoked via `tools/call` with the
+tool's snake_case `name`. Tools currently exposed:
 
-- `data_gov.search` — cursor-paginated; params `query`, `limit`,
-  `after`, `organization`, `organizationContains` (client-side
-  substring filter on org names)
-- `data_gov.dataset` — DCAT-US 3 metadata by slug
-- `data_gov.autocompleteDatasets` — capped full-text search
-- `data_gov.listOrganizations`
-- `data_gov.downloadResources` — params `datasetId`, optional
-  `outputDir`, optional `formats` filter (matched against `format` AND
-  `mediaType`), optional `distributionIndexes` (zero-based)
+- `data_gov_search` — cursor-paginated; arguments `query`, `limit` (1–1000),
+  `after`, `organization`, `organizationContains` (client-side substring
+  filter on org names)
+- `data_gov_dataset` — DCAT-US 3 metadata. Argument: `slug`
+- `data_gov_autocomplete_datasets` — capped full-text search; arguments
+  `partial`, `limit` (1–100)
+- `data_gov_list_organizations` — argument `limit` (1–1000)
+- `data_gov_download_resources` — arguments `datasetId` (slug), optional
+  `outputDir`, optional `formats` filter (case-insensitive substring match
+  against `format` or `mediaType` — so `"JSON"` matches `application/json`),
+  optional `distributionIndexes` (zero-based)
 
-Plus the MCP lifecycle methods (`initialize`, `tools/list`, `tools/call`,
-`shutdown`). The legacy `ckan.*` tools were removed in 0.4.0.
+Plus the MCP lifecycle methods (`initialize`, `initialized`, `shutdown`,
+`tools/list`, `tools/call`). The legacy `ckan.*` tools were removed in
+0.4.0.
+
+The same tools are also reachable as direct JSON-RPC methods under
+dot-camelCase names (`data_gov.search`, `data_gov.dataset`, etc.), but
+that's a non-MCP back-channel — generated code should always use
+`tools/call name=<snake_case>` so it works with any MCP client.
 
 ## Code-generation guidance
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ What's different about the new API:
   `download_distribution(s)`, `get_resource_filename` →
   `get_distribution_filename`.
 - **MCP server** drops the `ckan.*` tools and renames parameters on
-  `data_gov.search` and `data_gov.downloadResources`. See
+  `data_gov_search` and `data_gov_download_resources`. See
   [CHANGELOG.md](./CHANGELOG.md) for the full diff.
 
 ### What about `data-gov-ckan`?

--- a/data-gov-mcp-server/README.md
+++ b/data-gov-mcp-server/README.md
@@ -31,36 +31,42 @@ The process reads JSON-RPC 2.0 messages (one per line) from standard input and w
 
 ## Available Tools
 
-The MCP server exposes the following tools (methods):
+Tools are invoked the standard MCP way: `tools/call` with the tool's `name`
+and an `arguments` object. Discover them at runtime with `tools/list`.
 
 ### Data.gov tools
-- `data_gov.search` – Search datasets. Cursor-paginated via `after`, optional
-  `organization` slug filter, and a client-side `organizationContains`
-  substring filter. Response includes both the raw page and a compact
-  `summaries` array.
-- `data_gov.dataset` – Fetch full DCAT-US 3 metadata for a dataset by slug.
-- `data_gov.autocompleteDatasets` – Dataset title suggestions for a partial
+
+- `data_gov_search` — Search datasets. Cursor-paginated via `after`; optional
+  `organization` slug filter and a client-side `organizationContains`
+  substring filter. Response wraps the raw page plus a compact `summaries`
+  array.
+- `data_gov_dataset` — Fetch full DCAT-US 3 metadata for a dataset. Takes
+  `slug` (e.g., `electric-vehicle-population-data`).
+- `data_gov_autocomplete_datasets` — Dataset title suggestions for a partial
   query (implemented as a capped full-text search).
-- `data_gov.listOrganizations` – List publishing organizations.
-- `data_gov.downloadResources` – Download distributions to the local
-  filesystem, optionally limited by zero-based `distributionIndexes` and/or a
-  `formats` filter (matched against `format` and `mediaType`).
+- `data_gov_list_organizations` — List publishing organizations.
+- `data_gov_download_resources` — Download distributions to the local
+  filesystem. Optional `distributionIndexes` (zero-based) and `formats`
+  filter; `formats` is matched as a **case-insensitive substring** against
+  each distribution's `format` and `mediaType`, so `"JSON"` matches
+  `application/json`, `"CSV"` matches `text/csv`, etc.
 
 ### MCP protocol methods
-- `tools/list` – List available tools and their schemas.
-- `tools/call` – Invoke a tool by name with arguments.
-- `initialize`, `initialized`, `shutdown` – MCP protocol lifecycle.
 
-Each request follows the usual JSON-RPC 2.0 shape:
+- `tools/list` — List available tools and their schemas.
+- `tools/call` — Invoke a tool by name with arguments.
+- `initialize`, `initialized`, `shutdown` — MCP protocol lifecycle.
+
+A typical `tools/call` request:
 
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "data_gov.search",
+  "method": "tools/call",
   "params": {
-    "query": "climate",
-    "limit": 5
+    "name": "data_gov_search",
+    "arguments": { "query": "climate", "limit": 5 }
   }
 }
 ```
@@ -68,17 +74,28 @@ Each request follows the usual JSON-RPC 2.0 shape:
 Responses mirror the JSON-RPC 2.0 schema and either contain a `result`
 payload or an `error` object.
 
+#### Direct method dispatch (non-MCP clients)
+
+For raw JSON-RPC clients that don't go through `tools/call`, the same tools
+are also exposed under dot-camelCase method names: `data_gov.search`,
+`data_gov.dataset`, `data_gov.autocompleteDatasets`,
+`data_gov.listOrganizations`, `data_gov.downloadResources`. Standard MCP
+clients (VSCode, Claude Desktop, etc.) only see — and only need — the
+snake_case tool names above.
+
 ### Pagination
 
-`data_gov.search` uses cursor-based pagination. When there are more pages, the
-response body carries an `after` field. Pass it back unchanged on the next
-call:
+`data_gov_search` uses cursor-based pagination. When there are more pages,
+the response body carries an `after` field. Pass it back unchanged on the
+next call:
 
 ```jsonc
-{"method": "data_gov.search", "params": {"query": "climate", "limit": 20}}
-// response: { "results": [...], "after": "WzgxLjM...", ...}
+// Page 1
+{"method":"tools/call","params":{"name":"data_gov_search","arguments":{"query":"climate","limit":20}}}
+// response: { "results": [...], "after": "WzgxLjM...", ... }
 
-{"method": "data_gov.search", "params": {"query": "climate", "limit": 20, "after": "WzgxLjM..."}}
+// Page 2 — pass the cursor back as `after`
+{"method":"tools/call","params":{"name":"data_gov_search","arguments":{"query":"climate","limit":20,"after":"WzgxLjM..."}}}
 ```
 
 ## VSCode Integration

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -206,7 +206,7 @@ async fn dispatch_direct_tool_method_wraps_response() {
     let server = test_server(&mock.uri());
 
     let result = server
-        .dispatch("data_gov.dataset", Some(json!({ "id": "my-dataset" })))
+        .dispatch("data_gov.dataset", Some(json!({ "slug": "my-dataset" })))
         .await
         .expect("direct data_gov.dataset call should succeed");
 

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -70,11 +70,12 @@ impl DataGovMcpServer {
             "data_gov.search" => self.handle_search(method, params).await,
             "data_gov.dataset" => {
                 let params: DatasetParams = parse_required_params(method, params)?;
-                let result = self.data_gov.get_dataset(&params.id).await?;
+                let result = self.data_gov.get_dataset(&params.slug).await?;
                 Ok(serde_json::to_value(result).map_err(ServerError::Serialization)?)
             }
             "data_gov.autocompleteDatasets" => {
                 let params: AutocompleteParams = parse_required_params(method, params)?;
+                validate_limit(method, params.limit, 1, 100)?;
                 let result = self
                     .data_gov
                     .autocomplete_datasets(&params.partial, params.limit)
@@ -83,6 +84,7 @@ impl DataGovMcpServer {
             }
             "data_gov.listOrganizations" => {
                 let params: ListOrganizationsParams = parse_optional_params(method, params)?;
+                validate_limit(method, params.limit, 1, 1000)?;
                 let result = self.data_gov.list_organizations(params.limit).await?;
                 Ok(serde_json::to_value(result).map_err(ServerError::Serialization)?)
             }
@@ -98,6 +100,7 @@ impl DataGovMcpServer {
         params: Option<Value>,
     ) -> Result<Value, ServerError> {
         let params: SearchParams = parse_required_params(method, params)?;
+        validate_limit(method, params.limit, 1, 1000)?;
         let mut page = self
             .data_gov
             .search(
@@ -192,31 +195,40 @@ impl DataGovMcpServer {
             };
 
         if let Some(formats) = params.formats.as_ref() {
-            let available_formats: HashSet<String> = distributions
+            // Match user filters as case-insensitive substrings of either
+            // `format` or `mediaType`. DCAT-US 3 distributions usually leave
+            // `format` empty and populate `mediaType` with a full MIME type
+            // (e.g., "application/json"), so users typing "JSON" should still
+            // match. Empty filter strings are dropped — they would otherwise
+            // match every distribution.
+            let normalized_filters: Vec<String> = formats
                 .iter()
-                .flat_map(|d| {
-                    [d.format.as_deref(), d.media_type.as_deref()]
-                        .into_iter()
-                        .flatten()
-                        .map(|s| s.to_ascii_lowercase())
-                        .collect::<Vec<_>>()
-                })
+                .map(|f| f.trim().to_ascii_lowercase())
+                .filter(|f| !f.is_empty())
                 .collect();
 
-            let mut format_filter = HashSet::with_capacity(formats.len());
-            for fmt in formats {
-                let normalized = fmt.trim().to_ascii_lowercase();
-                if !available_formats.contains(&normalized) {
-                    unavailable_formats.push(fmt.trim().to_string());
+            let distribution_matches = |d: &Distribution, filter: &str| -> bool {
+                d.format
+                    .as_deref()
+                    .is_some_and(|f| f.to_ascii_lowercase().contains(filter))
+                    || d.media_type
+                        .as_deref()
+                        .is_some_and(|m| m.to_ascii_lowercase().contains(filter))
+            };
+
+            for (raw, normalized) in formats.iter().zip(normalized_filters.iter()) {
+                if !distributions
+                    .iter()
+                    .any(|d| distribution_matches(d, normalized))
+                {
+                    unavailable_formats.push(raw.trim().to_string());
                 }
-                format_filter.insert(normalized);
             }
 
             distributions.retain(|d| {
-                let fmt = d.format.as_deref().map(str::to_ascii_lowercase);
-                let media = d.media_type.as_deref().map(str::to_ascii_lowercase);
-                fmt.is_some_and(|f| format_filter.contains(&f))
-                    || media.is_some_and(|m| format_filter.contains(&m))
+                normalized_filters
+                    .iter()
+                    .any(|filter| distribution_matches(d, filter))
             });
         }
 

--- a/data-gov-mcp-server/src/server.rs
+++ b/data-gov-mcp-server/src/server.rs
@@ -85,8 +85,13 @@ impl DataGovMcpServer {
                 }
             };
 
+            // Per JSON-RPC 2.0: a request without an `id` is a notification, and
+            // the server MUST NOT reply. Still dispatch for side effects.
+            let is_notification = request.id.is_none();
             let response = self.handle_request(request).await;
-            self.write_response(&mut writer, &response).await?;
+            if !is_notification {
+                self.write_response(&mut writer, &response).await?;
+            }
         }
 
         Ok(())

--- a/data-gov-mcp-server/src/tools.rs
+++ b/data-gov-mcp-server/src/tools.rs
@@ -134,12 +134,12 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
             input_schema: json!({
                 "type": "object",
                 "properties": {
-                    "id": {
+                    "slug": {
                         "type": "string",
                         "description": "Dataset slug. Use the slug from search results or the dataset URL — do not construct or guess this value."
                     }
                 },
-                "required": ["id"],
+                "required": ["slug"],
                 "additionalProperties": false
             }),
         },

--- a/data-gov-mcp-server/src/types.rs
+++ b/data-gov-mcp-server/src/types.rs
@@ -154,6 +154,28 @@ where
     }
 }
 
+/// Reject `limit` values outside the inclusive `[min, max]` range advertised
+/// by the tool's input schema.
+///
+/// The schema is informational on the wire; we still need to enforce it before
+/// dispatching to upstream APIs that would otherwise return their own
+/// (uglier) 4xx errors and burn a network round-trip.
+pub(crate) fn validate_limit(
+    method: &str,
+    limit: Option<i32>,
+    min: i32,
+    max: i32,
+) -> ServerResult<()> {
+    if let Some(value) = limit
+        && !(min..=max).contains(&value)
+    {
+        return Err(ServerError::InvalidParams(format!(
+            "{method}: limit must be between {min} and {max}, got {value}"
+        )));
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // MCP parameter and result structs
 // ---------------------------------------------------------------------------
@@ -195,7 +217,8 @@ pub(crate) struct DatasetSummary {
 /// Parameters for `data_gov.dataset`.
 #[derive(Debug, Deserialize)]
 pub(crate) struct DatasetParams {
-    pub id: String,
+    /// data.gov dataset slug (e.g., `electric-vehicle-population-data`).
+    pub slug: String,
 }
 
 /// Parameters for `data_gov.autocompleteDatasets`.
@@ -314,10 +337,10 @@ mod tests {
 
     #[test]
     fn parse_required_params_succeeds_with_valid_json() {
-        let params = Some(json!({"id": "my-dataset"}));
+        let params = Some(json!({"slug": "my-dataset"}));
         let result: ServerResult<DatasetParams> = parse_required_params("test_method", params);
         let parsed = result.expect("should succeed");
-        assert_eq!(parsed.id, "my-dataset");
+        assert_eq!(parsed.slug, "my-dataset");
     }
 
     #[test]
@@ -338,6 +361,42 @@ mod tests {
         let params = Some(json!({"wrong_field": 42}));
         let result: ServerResult<DatasetParams> = parse_required_params("test_method", params);
         let err = result.expect_err("should fail");
+        assert!(matches!(err, ServerError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn validate_limit_accepts_none() {
+        validate_limit("m", None, 1, 1000).expect("None should pass");
+    }
+
+    #[test]
+    fn validate_limit_accepts_value_in_range() {
+        validate_limit("m", Some(1), 1, 1000).expect("min should pass");
+        validate_limit("m", Some(1000), 1, 1000).expect("max should pass");
+        validate_limit("m", Some(50), 1, 1000).expect("middle should pass");
+    }
+
+    #[test]
+    fn validate_limit_rejects_below_min() {
+        let err = validate_limit("m", Some(0), 1, 1000).expect_err("below min should fail");
+        match err {
+            ServerError::InvalidParams(msg) => {
+                assert!(msg.contains("between 1 and 1000"), "got: {msg}");
+                assert!(msg.contains("got 0"), "got: {msg}");
+            }
+            other => panic!("expected InvalidParams, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_limit_rejects_above_max() {
+        let err = validate_limit("m", Some(1500), 1, 1000).expect_err("above max should fail");
+        assert!(matches!(err, ServerError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn validate_limit_rejects_negative() {
+        let err = validate_limit("m", Some(-1), 1, 1000).expect_err("negative should fail");
         assert!(matches!(err, ServerError::InvalidParams(_)));
     }
 

--- a/examples/vscode-workspace/.github/instructions/mcp-server-usage.instructions.md
+++ b/examples/vscode-workspace/.github/instructions/mcp-server-usage.instructions.md
@@ -16,20 +16,22 @@ When working with data.gov datasets:
    calls. The tool is cursor-paginated — pass the `after` value from the
    previous response to fetch the next page. An optional
    `organizationContains` substring filter is applied client-side.
-2. **Dataset details**: Use `mcp_data-gov_data_gov_dataset` (lookup by slug)
-   instead of curl/wget to fetch DCAT-US 3 metadata.
+2. **Dataset details**: Use `mcp_data-gov_data_gov_dataset` instead of
+   curl/wget to fetch DCAT-US 3 metadata. Argument: `slug` (e.g.,
+   `electric-vehicle-population-data`).
 3. **Listing organizations**: Use
-   `mcp_data-gov_data_gov_listOrganizations`.
-4. **Autocomplete**: Use `mcp_data-gov_data_gov_autocompleteDatasets` for
+   `mcp_data-gov_data_gov_list_organizations`.
+4. **Autocomplete**: Use `mcp_data-gov_data_gov_autocomplete_datasets` for
    dataset title suggestions.
-5. **Downloading files**: Use `mcp_data-gov_data_gov_downloadResources`
+5. **Downloading files**: Use `mcp_data-gov_data_gov_download_resources`
    instead of wget, curl, or other download tools.
-   - It accepts: `datasetId` (slug), optional `outputDir`, optional
-     `formats` filter (matched against both `format` and `mediaType`),
-     and optional `distributionIndexes` (zero-based indexes of the
-     distributions to download). The legacy `resourceIds` parameter no
-     longer exists — data.gov's Catalog API exposes DCAT distributions
-     rather than CKAN resources.
+   - Accepts: `datasetId` (slug), optional `outputDir`, optional `formats`
+     filter (case-insensitive substring match against `format` or
+     `mediaType`, so `"JSON"` matches `application/json`), and optional
+     `distributionIndexes` (zero-based indexes into the downloadable
+     distributions list). The legacy `resourceIds` parameter no longer
+     exists — data.gov's Catalog API exposes DCAT distributions rather than
+     CKAN resources.
    - Provides automatic error handling, format filtering, and structured
      results.
 


### PR DESCRIPTION
## Summary

End-to-end smoke testing of the MCP server (post-#22 catalog migration) surfaced five issues. This PR fixes four of them; #29 is deferred pending a check on VSCode MCP behavior.

| Issue | Fix |
| --- | --- |
| #28 — server replies to JSON-RPC notifications | Track notification status (no `id`) in the request loop and skip the response write |
| #27 — schema-declared `limit` bounds not enforced | New `validate_limit` helper in `types.rs`; called at the top of `data_gov_search`, `data_gov_autocomplete_datasets`, and `data_gov_list_organizations` handlers; 5 new unit tests |
| #30 — format filter is case-insensitive equality | Switch to case-insensitive **substring** match against either `format` or `mediaType` so `"JSON"` matches `application/json`, `"CSV"` matches `text/csv`, etc. Empty filter strings dropped to avoid match-everything |
| #26 — `data_gov_dataset` param named `id` but takes a slug | Rename to `slug` in the schema, the `DatasetParams` struct, the dispatch test, and all docs |
| #26 — docs used dot-camelCase tool names | Rewrite user-facing docs to lead with snake_case MCP tool names invoked via `tools/call` (the form clients actually see) |

## What's deferred

#29 — the server emits an unsolicited "ready" line on stdout before the client speaks. Non-MCP-spec, but the maintainer wants to confirm whether VSCode integration depends on it before removing.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all green; MCP test count goes 49 → 54
- [x] End-to-end smoke test confirmed: notification produces no response; `limit` out-of-range now returns `-32602` from the local layer (not a network 400); old `id` param fails fast with `missing field "slug"`; new `slug` param works; CSV/JSON format filters match `text/csv` / `application/json` mediaTypes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)