### PR TITLE
REPL: Unix-fs metaphor for cd/ls/show with full path validation (#34 #35 #37)

### DIFF
--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -303,15 +303,17 @@ impl CatalogClient {
     ///
     /// # Notes
     ///
-    /// The Catalog API silently ignores unmatched `slug=` values and returns
-    /// the top result by relevance instead of an empty page. To prevent that
-    /// from leaking out as silent data corruption, this method explicitly
-    /// requires the returned hit's `slug` to equal the requested one.
+    /// The Catalog API does not actually honor a `slug=` query parameter
+    /// today — it returns the top relevance hit regardless of the value.
+    /// We work around this by using a full-text query (`q=<slug>`) and then
+    /// scanning the first page for a hit whose `slug` exactly matches.
+    /// Slug-shaped queries reliably rank the exact match first when it
+    /// exists; we look at the top 20 results to leave headroom for ties.
     pub async fn dataset_by_slug(
         &self,
         slug: &str,
     ) -> Result<Option<models::SearchHit>, CatalogError> {
-        let params = SearchParams::new().slug(slug).per_page(1);
+        let params = SearchParams::new().q(slug).per_page(20);
         let response: models::SearchResponse = self.search(params).await?;
         Ok(response
             .results

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -300,13 +300,23 @@ impl CatalogClient {
     /// Returns `Ok(None)` if no dataset with that slug exists. The returned
     /// [`SearchHit`](models::SearchHit) carries the denormalized fields and a
     /// nested `dcat` record with the full DCAT-US 3 metadata.
+    ///
+    /// # Notes
+    ///
+    /// The Catalog API silently ignores unmatched `slug=` values and returns
+    /// the top result by relevance instead of an empty page. To prevent that
+    /// from leaking out as silent data corruption, this method explicitly
+    /// requires the returned hit's `slug` to equal the requested one.
     pub async fn dataset_by_slug(
         &self,
         slug: &str,
     ) -> Result<Option<models::SearchHit>, CatalogError> {
         let params = SearchParams::new().slug(slug).per_page(1);
-        let mut response: models::SearchResponse = self.search(params).await?;
-        Ok(response.results.pop())
+        let response: models::SearchResponse = self.search(params).await?;
+        Ok(response
+            .results
+            .into_iter()
+            .find(|hit| hit.slug.as_deref() == Some(slug)))
     }
 
     /// List all organizations known to the catalog.

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -96,24 +96,17 @@ async fn dataset_by_slug_returns_first_hit() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/search"))
-        .and(query_param(
-            "slug",
-            "tiger-line-shapefile-2022-nation-u-s-2020-census-5-digit-zip-code-tabulation-area-zcta5",
-        ))
+        .and(query_param("slug", "crime-data-from-2020-to-present"))
         .respond_with(
-            ResponseTemplate::new(200).set_body_raw(
-                fixture("search_by_slug.json"),
-                "application/json",
-            ),
+            ResponseTemplate::new(200)
+                .set_body_raw(fixture("search_by_slug.json"), "application/json"),
         )
         .mount(&server)
         .await;
 
     let client = client_for(&server);
     let hit = client
-        .dataset_by_slug(
-            "tiger-line-shapefile-2022-nation-u-s-2020-census-5-digit-zip-code-tabulation-area-zcta5",
-        )
+        .dataset_by_slug("crime-data-from-2020-to-present")
         .await
         .expect("slug lookup succeeds")
         .expect("slug matches a dataset");
@@ -137,6 +130,33 @@ async fn dataset_by_slug_returns_none_when_empty() {
     let client = client_for(&server);
     let result = client.dataset_by_slug("nonexistent").await.unwrap();
     assert!(result.is_none());
+}
+
+/// The live Catalog API silently ignores unmatched `slug=` values and
+/// returns the top result by relevance instead of an empty page. Make
+/// sure the client guards against that and returns `None` rather than
+/// the wrong dataset.
+#[tokio::test]
+async fn dataset_by_slug_returns_none_when_top_hit_has_a_different_slug() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "slug": "crime-data-from-2020-to-present",
+                "title": "Crime Data from 2020 to 2024"
+            }],
+            "sort": "relevance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let result = client.dataset_by_slug("nasa-thesaurus").await.unwrap();
+    assert!(
+        result.is_none(),
+        "expected None when API returns a hit with a different slug, got Some(_)"
+    );
 }
 
 #[tokio::test]

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -94,9 +94,11 @@ async fn search_with_org_slug_passes_filter() {
 #[tokio::test]
 async fn dataset_by_slug_returns_first_hit() {
     let server = MockServer::start().await;
+    // dataset_by_slug uses q=<slug> (the API doesn't honor slug= today)
+    // and matches the slug client-side.
     Mock::given(method("GET"))
         .and(path("/search"))
-        .and(query_param("slug", "crime-data-from-2020-to-present"))
+        .and(query_param("q", "crime-data-from-2020-to-present"))
         .respond_with(
             ResponseTemplate::new(200)
                 .set_body_raw(fixture("search_by_slug.json"), "application/json"),
@@ -132,10 +134,10 @@ async fn dataset_by_slug_returns_none_when_empty() {
     assert!(result.is_none());
 }
 
-/// The live Catalog API silently ignores unmatched `slug=` values and
-/// returns the top result by relevance instead of an empty page. Make
-/// sure the client guards against that and returns `None` rather than
-/// the wrong dataset.
+/// The live Catalog API doesn't honor a `slug=` query parameter — it
+/// returns the top relevance hit regardless. We work around it with
+/// `q=<slug>` plus a client-side slug-equality check. Make sure that
+/// check actually fires when the API returns a non-matching hit.
 #[tokio::test]
 async fn dataset_by_slug_returns_none_when_top_hit_has_a_different_slug() {
     let server = MockServer::start().await;
@@ -156,6 +158,38 @@ async fn dataset_by_slug_returns_none_when_top_hit_has_a_different_slug() {
     assert!(
         result.is_none(),
         "expected None when API returns a hit with a different slug, got Some(_)"
+    );
+}
+
+/// When the response includes the requested slug among multiple hits
+/// (for example, a `q=<slug>` query that fans out to similarly-named
+/// datasets), `dataset_by_slug` should pick the exact match rather than
+/// the top-ranked or first hit.
+#[tokio::test]
+async fn dataset_by_slug_picks_exact_match_among_multiple_hits() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [
+                { "slug": "ev-population-history", "title": "Decoy 1" },
+                { "slug": "electric-vehicle-population-data", "title": "Real" },
+                { "slug": "ev-population-by-county",   "title": "Decoy 2" }
+            ],
+            "sort": "relevance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let hit = client
+        .dataset_by_slug("electric-vehicle-population-data")
+        .await
+        .unwrap()
+        .expect("exact match should be found");
+    assert_eq!(
+        hit.slug.as_deref(),
+        Some("electric-vehicle-population-data")
     );
 }
 

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -193,9 +193,11 @@ async fn dispatch_tools_call_missing_params_returns_invalid_params() {
 #[tokio::test]
 async fn dispatch_direct_tool_method_wraps_response() {
     let mock = MockServer::start().await;
+    // dataset_by_slug uses q=<slug> on the wire (the API doesn't honor slug=)
+    // and matches the slug client-side.
     Mock::given(wm_method("GET"))
         .and(wm_path("/search"))
-        .and(query_param("slug", "my-dataset"))
+        .and(query_param("q", "my-dataset"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(search_body("my-dataset", "My Dataset")),
         )

--- a/data-gov/tools/cli/ui/commands.rs
+++ b/data-gov/tools/cli/ui/commands.rs
@@ -18,8 +18,11 @@ pub enum ReplCommand {
         args: Vec<String>,
     },
     List {
-        what: String,
-    }, // organizations, formats, etc.
+        /// Explicit subject (`organizations`/`orgs`). When `None`, the command
+        /// is context-dependent: at root it lists organizations, at an org it
+        /// lists that org's datasets, and at a dataset it lists distributions.
+        what: Option<String>,
+    },
     Select {
         path: String,
     },
@@ -214,12 +217,14 @@ impl ReplCommand {
                 })
             }
             "list" | "ls" => {
-                if parts.len() != 2 {
-                    return Err("Usage: list <organizations|orgs>".to_string());
-                }
-                Ok(ReplCommand::List {
-                    what: parts[1].clone(),
-                })
+                let what = match parts.len() {
+                    1 => None,
+                    2 => Some(parts[1].clone()),
+                    _ => {
+                        return Err("Usage: ls [organizations|orgs]".to_string());
+                    }
+                };
+                Ok(ReplCommand::List { what })
             }
             "lcd" | "setdir" => {
                 if parts.len() != 2 {

--- a/data-gov/tools/cli/ui/display.rs
+++ b/data-gov/tools/cli/ui/display.rs
@@ -116,8 +116,8 @@ pub fn print_cli_help() {
             "search \"climate data\" 20",
         ),
         (
-            "show [dataset_slug]",
-            "Show dataset info (uses active dataset if omitted)",
+            "show [dataset_slug|.]",
+            "Show dataset info ('.' or omitted means current dataset)",
             "show electric-vehicle-population-data",
         ),
         (
@@ -127,13 +127,13 @@ pub fn print_cli_help() {
         ),
         (
             "cd <path>",
-            "Navigate org/dataset context (like cd)",
-            "cd nasa-gov",
+            "Navigate to an org or dataset (validated against the catalog)",
+            "cd /nasa-gov",
         ),
         (
-            "list organizations",
-            "List government organizations",
-            "list organizations",
+            "ls",
+            "List the contents of the current location (orgs / datasets / distributions)",
+            "ls",
         ),
         ("info", "Show client and session information", "info"),
     ];
@@ -178,11 +178,15 @@ pub fn print_repl_help() {
             "Download distributions (by index or title)",
             "download electric-vehicle-population-data 0",
         ),
-        ("cd <path>", "Navigate org/dataset context", "cd epa-gov"),
         (
-            "list organizations",
-            "List government organizations",
-            "list orgs",
+            "cd <path>",
+            "Navigate to an org or dataset (validated against the catalog)",
+            "cd /epa-gov",
+        ),
+        (
+            "ls",
+            "List orgs (at root), datasets (at /<org>), or distributions (at /<org>/<dataset>)",
+            "ls",
         ),
         (
             "lcd <path>",

--- a/data-gov/tools/cli/ui/handlers.rs
+++ b/data-gov/tools/cli/ui/handlers.rs
@@ -15,10 +15,18 @@ fn resolve_dataset<'a>(
     explicit: &'a Option<String>,
     ctx: &'a SessionContext,
 ) -> Result<&'a str, &'static str> {
-    explicit
-        .as_deref()
-        .or(ctx.dataset.as_deref())
-        .ok_or("no dataset specified and none selected (use: select /org/dataset)")
+    match explicit.as_deref() {
+        // `.` is an alias for "current dataset" — like in any unix shell.
+        Some(".") => ctx
+            .dataset
+            .as_deref()
+            .ok_or("'.' refers to the current dataset, but no dataset is selected"),
+        Some(slug) => Ok(slug),
+        None => ctx
+            .dataset
+            .as_deref()
+            .ok_or("no dataset specified and none selected (use: cd /<slug>)"),
+    }
 }
 
 /// Execute a command (shared between REPL and CLI modes).
@@ -46,11 +54,11 @@ pub fn execute_command(
         }
 
         ReplCommand::List { what } => {
-            handle_list(client, rt, &what)?;
+            handle_list(client, rt, ctx, what.as_deref())?;
         }
 
         ReplCommand::Select { path } => {
-            handle_select(ctx, &path)?;
+            handle_select(client, rt, ctx, &path)?;
         }
 
         ReplCommand::Info => {
@@ -77,9 +85,130 @@ pub fn execute_command(
 }
 
 /// Handle select/cd command.
-fn handle_select(ctx: &mut SessionContext, path: &str) -> Result<(), Box<dyn std::error::Error>> {
-    ctx.apply_navigate(path)?;
+fn handle_select(
+    client: &DataGovClient,
+    rt: &Runtime,
+    ctx: &mut SessionContext,
+    path: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Single-segment paths (absolute `/foo`, or relative `foo` from root) are
+    // ambiguous in data.gov's flat slug namespace — `foo` could be an
+    // organization OR a dataset. The string-only `apply_navigate` always
+    // treats them as orgs; here we do the actual catalog lookup to
+    // disambiguate.
+    if let Some(slug) = ambiguous_single_segment(ctx, path) {
+        return resolve_single_segment_cd(client, rt, ctx, slug);
+    }
 
+    // For everything else, parse locally to a candidate context, then verify
+    // the candidate exists in the catalog before adopting it. Validating
+    // before applying means a failed `cd` leaves the user where they were.
+    let mut candidate = ctx.clone();
+    candidate.apply_navigate(path)?;
+    validate_candidate_exists(client, rt, &candidate)?;
+    *ctx = candidate;
+    print_select_result(ctx);
+    Ok(())
+}
+
+/// If `path` is a single segment whose semantics are ambiguous between org
+/// and dataset, return that segment. Trailing slashes are tolerated.
+///
+/// The two ambiguous cases:
+/// - `/<seg>` — absolute, single segment
+/// - `<seg>` — relative, when no org is currently set (so it would otherwise
+///   be parsed as an org by [`SessionContext::apply_relative`]).
+fn ambiguous_single_segment<'a>(ctx: &SessionContext, path: &'a str) -> Option<&'a str> {
+    if let Some(rest) = path.strip_prefix('/') {
+        let inner = rest.trim_end_matches('/');
+        if inner.is_empty() || inner.contains('/') {
+            return None;
+        }
+        return Some(inner);
+    }
+    let trimmed = path.trim_end_matches('/');
+    if trimmed.is_empty() || trimmed == ".." || trimmed.contains('/') {
+        return None;
+    }
+    if ctx.org.is_some() {
+        // At org level, a relative single segment is unambiguously a dataset.
+        return None;
+    }
+    Some(trimmed)
+}
+
+/// Resolve a single-segment `cd` against the live catalog: try as an org
+/// first (cheap — one bulk call), fall back to a dataset slug lookup. If
+/// the segment matches a dataset, populate the org context from the
+/// dataset's publishing organization so the prompt and downstream commands
+/// have a complete location.
+fn resolve_single_segment_cd(
+    client: &DataGovClient,
+    rt: &Runtime,
+    ctx: &mut SessionContext,
+    slug: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let orgs = rt.block_on(client.list_organizations(None))?;
+    if orgs.iter().any(|s| s == slug) {
+        ctx.org = Some(slug.to_string());
+        ctx.dataset = None;
+        print_select_result(ctx);
+        return Ok(());
+    }
+
+    match rt.block_on(client.get_dataset(slug)) {
+        Ok(hit) => {
+            ctx.org = hit.organization.as_ref().and_then(|o| o.slug.clone());
+            ctx.dataset = Some(slug.to_string());
+            print_select_result(ctx);
+            Ok(())
+        }
+        Err(_) => Err(format!(
+            "'{slug}' matches no organization or dataset (run `ls` to see what's at the current level)"
+        )
+        .into()),
+    }
+}
+
+/// Verify that the candidate context names entities that actually exist.
+/// `dataset_by_slug` already verifies the slug matches (so we can trust
+/// `Ok` here means it exists); the org check is a single membership test
+/// against the bulk organizations list.
+fn validate_candidate_exists(
+    client: &DataGovClient,
+    rt: &Runtime,
+    candidate: &SessionContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(slug) = candidate.dataset.as_deref() {
+        let hit = rt
+            .block_on(client.get_dataset(slug))
+            .map_err(|_| format!("dataset '{slug}' not found"))?;
+
+        if let Some(expected_org) = candidate.org.as_deref() {
+            let actual_org = hit.organization.as_ref().and_then(|o| o.slug.as_deref());
+            if let Some(actual) = actual_org
+                && actual != expected_org
+            {
+                return Err(format!(
+                    "dataset '{slug}' belongs to organization '{actual}', not '{expected_org}'"
+                )
+                .into());
+            }
+        }
+        return Ok(());
+    }
+
+    if let Some(org) = candidate.org.as_deref() {
+        let orgs = rt.block_on(client.list_organizations(None))?;
+        if !orgs.iter().any(|o| o == org) {
+            return Err(format!("organization '{org}' not found").into());
+        }
+    }
+
+    Ok(())
+}
+
+fn print_select_result(ctx: &SessionContext) {
     let label = ctx.prompt_label();
     if label.is_empty() {
         println!("{} Selection cleared", color_green_bold("OK"));
@@ -90,8 +219,6 @@ fn handle_select(ctx: &mut SessionContext, path: &str) -> Result<(), Box<dyn std
             color_yellow_bold(&label)
         );
     }
-
-    Ok(())
 }
 
 /// Handle search command.
@@ -402,33 +529,134 @@ fn print_download_summary(results: &[Result<std::path::PathBuf, data_gov::DataGo
     );
 }
 
-/// Handle list command.
+/// Handle list command. Behavior depends on the explicit subject and the
+/// current session context:
+///
+/// - `ls organizations` (or `ls orgs`) — list all organizations regardless
+///   of context.
+/// - `ls` at root — same as `ls organizations`.
+/// - `ls` at `/<org>` — list that org's datasets.
+/// - `ls` at `/<org>/<dataset>` (or `//<dataset>`) — list distributions of
+///   the current dataset.
 fn handle_list(
     client: &DataGovClient,
     rt: &Runtime,
-    what: &str,
+    ctx: &SessionContext,
+    what: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    match what.to_lowercase().as_str() {
-        "organizations" | "orgs" => {
-            println!("{} organizations...", color_cyan("Fetching"));
-
-            let orgs = rt.block_on(client.list_organizations(Some(50)))?;
-
-            println!("\n{} organizations:", color_green_bold("Government"));
-            for (i, org) in orgs.iter().enumerate() {
-                println!(
-                    "{}. {}",
-                    color_blue_bold(&format!("{:2}", i + 1)),
-                    color_yellow(org)
-                );
+    if let Some(subject) = what {
+        match subject.to_lowercase().as_str() {
+            "organizations" | "orgs" => {
+                return list_organizations(client, rt);
             }
-        }
-        _ => {
-            println!("{} Unknown list type: {}", color_red_bold("Error:"), what);
-            println!("Available: {}", color_blue("organizations"));
+            other => {
+                println!("{} Unknown list type: {}", color_red_bold("Error:"), other);
+                println!("Available: {}", color_blue("organizations"));
+                return Ok(());
+            }
         }
     }
 
+    match (&ctx.org, &ctx.dataset) {
+        (_, Some(slug)) => list_dataset_distributions(client, rt, slug),
+        (Some(org), None) => list_org_datasets(client, rt, org),
+        (None, None) => list_organizations(client, rt),
+    }
+}
+
+fn list_organizations(
+    client: &DataGovClient,
+    rt: &Runtime,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{} organizations...", color_cyan("Fetching"));
+    let orgs = rt.block_on(client.list_organizations(Some(50)))?;
+    println!("\n{} organizations:", color_green_bold("Government"));
+    for (i, org) in orgs.iter().enumerate() {
+        println!(
+            "{}. {}",
+            color_blue_bold(&format!("{:2}", i + 1)),
+            color_yellow(org)
+        );
+    }
+    Ok(())
+}
+
+fn list_org_datasets(
+    client: &DataGovClient,
+    rt: &Runtime,
+    org: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{} datasets in '{}'...", color_cyan("Fetching"), org);
+    // Empty query + organization filter = "all datasets in this org".
+    let page = rt.block_on(client.search("", Some(50), None, Some(org)))?;
+    if page.results.is_empty() {
+        println!(
+            "{} No datasets found in '{}'.",
+            color_yellow_bold("Note:"),
+            org
+        );
+        return Ok(());
+    }
+    let suffix = if page.after.is_some() {
+        " (more available — pagination not yet implemented)"
+    } else {
+        ""
+    };
+    println!(
+        "\n{} {} datasets in {}{}:",
+        color_green_bold("Found"),
+        page.results.len(),
+        color_yellow(org),
+        suffix
+    );
+    for (i, hit) in page.results.iter().enumerate() {
+        let slug = hit.slug.as_deref().unwrap_or("(no-slug)");
+        let title = hit.title.as_deref().unwrap_or("");
+        println!(
+            "{}. {} {}",
+            color_blue_bold(&format!("{:2}", i + 1)),
+            color_yellow_bold(slug),
+            color_dimmed(title)
+        );
+    }
+    Ok(())
+}
+
+fn list_dataset_distributions(
+    client: &DataGovClient,
+    rt: &Runtime,
+    slug: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("{} distributions of '{}'...", color_cyan("Fetching"), slug);
+    let hit = rt.block_on(client.get_dataset(slug))?;
+    let distributions = downloadable_for(&hit)?;
+    if distributions.is_empty() {
+        println!(
+            "{} No downloadable distributions in '{}'.",
+            color_yellow_bold("Note:"),
+            slug
+        );
+        return Ok(());
+    }
+    println!(
+        "\n{} {} distributions:",
+        color_green_bold("Found"),
+        distributions.len()
+    );
+    for (i, dist) in distributions.iter().enumerate() {
+        let title = dist.title.as_deref().unwrap_or("(untitled)");
+        let format = dist
+            .format
+            .as_deref()
+            .or(dist.media_type.as_deref())
+            .unwrap_or("?");
+        println!(
+            "{}. {} [{}]",
+            color_blue_bold(&format!("{:2}", i + 1)),
+            color_yellow(title),
+            color_dimmed(format)
+        );
+    }
     Ok(())
 }
 

--- a/data-gov/tools/cli/ui/handlers.rs
+++ b/data-gov/tools/cli/ui/handlers.rs
@@ -201,6 +201,18 @@ fn handle_download(
         let id = ctx.dataset.as_deref().unwrap();
         (id, args)
     } else if let Some(first) = args.first() {
+        // Guard: a numeric first arg with no dataset in context is almost
+        // always a user mistake — they meant `download <index>` after
+        // selecting a dataset, but no dataset is selected. Without this
+        // guard the digit would be sent to the catalog as a "slug" and we
+        // would download whatever the API returned for it (data.gov
+        // silently ignores unmatched slugs and returns the top result).
+        if first.chars().all(|c| c.is_ascii_digit()) {
+            return Err(format!(
+                "no dataset selected — to download by index, first navigate into a dataset (e.g. `cd /<slug>`); '{first}' is not a valid dataset slug"
+            )
+            .into());
+        }
         (first.as_str(), &args[1..])
     } else {
         return Err("no dataset specified and none selected (use: select /org/dataset)".into());


### PR DESCRIPTION
## Summary

Implements the Unix-filesystem metaphor for the `data-gov` REPL the user laid out in #37: the data.gov catalog as a four-level tree of root → orgs → datasets → distributions, with `cd`/`ls`/`show`/`download` consistent at every level and every path validated against the live catalog before being adopted.

This sits on top of PR #36 (which fixes `dataset_by_slug` to actually work against the live API). **#36 needs to merge first**; this PR will rebase cleanly on top.

## Behavior

```
data-gov:/> ls
... organizations ...
data-gov:/> cd /nasa
OK Active context: /nasa
data-gov:/nasa> ls
... 50 datasets in nasa ...
data-gov:/nasa> cd nasa-thesaurus       # resolves as dataset
OK Active context: /nasa/nasa-thesaurus
data-gov:/nasa/nasa-thesaurus> show .
... dataset details ...
data-gov:/nasa/nasa-thesaurus> cd ..
OK Active context: /nasa
data-gov:/nasa> cd /this-is-not-a-real-slug
Error: 'this-is-not-a-real-slug' matches no organization or dataset
       (run `ls` to see what's at the current level)
```

## What changed

- **`cd /<slug>` (single absolute segment) auto-resolves.** Previously always treated as an org. Now checks the bulk org list first; if no match, falls back to `dataset_by_slug`. When the segment matches a dataset, the org context is auto-populated from that dataset's publishing org so the prompt is honest. (#34)
- **`cd <slug>` from root (single relative segment)** uses the same resolver — same ambiguity.
- **Every `cd` is validated** before the new context is committed. Failed cd leaves the previous context intact. Two-segment forms (`cd /<org>/<dataset>`) verify the dataset exists AND its publisher org matches the path's org segment.
- **`show .`** now resolves to the current session's dataset slug, like in any unix shell. Errors clearly when no dataset is selected. (#35)
- **`ls` is context-aware**: at `/` lists orgs (same as `ls organizations`), at `/<org>` lists datasets in that org (new — capped at 50, "more available" surfaced when cursor non-empty; full pagination is part of #5/#37), at `/<org>/<dataset>` lists distributions.
- **Help text** in both CLI and REPL modes updated to describe the new semantics; `show` help mentions the `.` alias.

## Trade-offs

Every `cd` makes 1–2 catalog calls (org list, possibly `dataset_by_slug`). That's the cost of validating before adopting. The REPL is interactive so the latency is acceptable, and the alternative is the silent-corruption / "downloaded LA crime data" class of bug that #36 just fixed.

## What's deferred

Still part of #37 / related issues, not in this PR:
- Real pagination for `ls` at org level (currently capped at 50 with a "more available" hint) — overlaps with #5
- Richer `ls` output (descriptions, distribution counts, last-harvested-date)
- Caching the org list across `cd`s in a session

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all green
- [x] Live walkthrough against catalog.data.gov:
  - `ls` at root shows orgs
  - `cd /nasa` works; `ls` shows 50 datasets
  - `cd /nasa-thesaurus` resolves to dataset; org auto-populated to nasa
  - `cd ..` walks back up
  - `show .` from a dataset works; errors cleanly with no context
  - `cd /<bogus>` errors clearly without changing context
- [ ] CI passes once #36 merges and this rebases

🤖 Generated with [Claude Code](https://claude.com/claude-code)