### PR TITLE
Show distributions in ls as 0-indexed to match download N

### DIFF
--- a/data-gov/tools/cli/ui/handlers.rs
+++ b/data-gov/tools/cli/ui/handlers.rs
@@ -643,6 +643,10 @@ fn list_dataset_distributions(
         color_green_bold("Found"),
         distributions.len()
     );
+    // Distributions are zero-indexed because `download N` is zero-indexed
+    // (and the `show` output already displays them that way). Don't tempt
+    // anyone to type `download 1` after seeing `1.` and getting the second
+    // distribution instead of the first.
     for (i, dist) in distributions.iter().enumerate() {
         let title = dist.title.as_deref().unwrap_or("(untitled)");
         let format = dist
@@ -652,7 +656,7 @@ fn list_dataset_distributions(
             .unwrap_or("?");
         println!(
             "{}. {} [{}]",
-            color_blue_bold(&format!("{:2}", i + 1)),
+            color_blue_bold(&format!("{:2}", i)),
             color_yellow(title),
             color_dimmed(format)
         );


### PR DESCRIPTION
## Summary

The new context-aware `ls` at the dataset level was rendering distributions as `1.`, `2.`, `3.` — while `download N` and the existing `show` output use 0-based indexing. So `ls` showed `1.` at the top and `download 1` grabbed the *second* distribution instead.

Reported concretely by the user at `/nasa/flight-crew-physiological-data-for-crew-state-monitoring`: typed `download 1` expecting `1.` (10.zip) and got `2.` (11.zip).

## Fix

One-line change in `list_dataset_distributions`: index column is now `i` (0-based) instead of `i + 1`. Layout (right-padded to 2 chars) is preserved so distributions ≥10 still line up.

Org and dataset listings stay 1-indexed — they're addressed by slug, not by index, so no off-by-one risk.

## Test plan

- [x] `cargo fmt --all -- --check` / `cargo clippy -D warnings` / `cargo test --all-features`
- [x] Live verify: `cd /electric-vehicle-population-data` → `ls` now shows `0. ...` `1. ...` `2. ...` `3. ...`
- [ ] CI passes

## Side note

While testing this, I hit a separate bug at `/epa` — `ls` failed with `invalid type: null, expected a sequence at line 1 column 113903`. Some catalog response contains `null` where one of our models expects an array. Will file as a follow-up if you can confirm you saw it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)