### PR TITLE
Tolerate null for Vec<T> fields in catalog models (closes #40)

### DIFF
--- a/data-gov-catalog/src/models.rs
+++ b/data-gov-catalog/src/models.rs
@@ -7,11 +7,26 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+/// Deserialize a JSON `null` as `T::default()`.
+///
+/// `#[serde(default)]` alone covers the *missing field* case but doesn't
+/// help when the field is *present and explicitly null*. The Catalog API
+/// returns `null` for empty repeated DCAT-US 3 fields like `references`,
+/// `keyword`, etc., so every `Vec<T>` field on these models needs this
+/// extra hop to avoid `invalid type: null, expected a sequence` panics.
+fn deserialize_null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: serde::Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 /// Envelope returned by the `/search` endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResponse {
     /// Datasets matching the query on this page.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub results: Vec<SearchHit>,
     /// Opaque cursor for the next page. Absent on the last page.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -46,10 +61,10 @@ pub struct SearchHit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization: Option<Organization>,
     /// Free-form tags.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub keyword: Vec<String>,
     /// DCAT-US themes (broad subject categories).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub theme: Vec<String>,
     /// Whether this dataset advertises spatial coverage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -61,7 +76,7 @@ pub struct SearchHit {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_harvested_date: Option<String>,
     /// Distribution titles listed out for convenience (may be empty).
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub distribution_titles: Vec<String>,
     /// URL of the harvest record for this dataset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -122,12 +137,12 @@ pub struct Dataset {
         rename = "contactPoint"
     )]
     pub contact_point: Option<ContactPoint>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub keyword: Vec<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub theme: Vec<String>,
     /// Downloadable / accessible representations of the dataset.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub distribution: Vec<Distribution>,
     /// Publisher's landing page for this dataset.
     #[serde(
@@ -150,7 +165,7 @@ pub struct Dataset {
         rename = "accrualPeriodicity"
     )]
     pub accrual_periodicity: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub language: Vec<String>,
     #[serde(
         default,
@@ -177,7 +192,7 @@ pub struct Dataset {
         rename = "describedByType"
     )]
     pub described_by_type: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub references: Vec<String>,
     #[serde(
         default,
@@ -278,7 +293,7 @@ impl ContactPoint {
 /// Envelope returned by `/api/organizations`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrganizationsResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub organizations: Vec<Organization>,
     #[serde(default)]
     pub total: i64,
@@ -303,14 +318,14 @@ pub struct Organization {
     pub dataset_count: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_count: Option<i64>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub aliases: Vec<String>,
 }
 
 /// Envelope returned by `/api/keywords`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeywordsResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub keywords: Vec<KeywordCount>,
     #[serde(default)]
     pub total: i64,
@@ -330,7 +345,7 @@ pub struct KeywordCount {
 /// Envelope returned by `/api/locations/search`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationsResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub locations: Vec<Location>,
     #[serde(default)]
     pub total: i64,

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -235,6 +235,58 @@ async fn keywords_passes_size_and_min_count() {
     assert!(kw.keywords[0].count > 0);
 }
 
+/// The Catalog API returns `null` for empty repeated DCAT-US 3 fields
+/// (observed: `references`, `rights`, also seen elsewhere on `keyword`,
+/// `theme`, etc.). With plain `#[serde(default)]` only the *missing*
+/// case is covered; an explicit `null` value blows up with
+/// `invalid type: null, expected a sequence`. Make sure every `Vec<T>`
+/// field tolerates `null` and treats it as empty.
+#[tokio::test]
+async fn search_tolerates_null_for_repeated_fields() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "slug": "with-nulls",
+                "title": "Has nulls everywhere a Vec is expected",
+                "keyword": null,
+                "theme": null,
+                "distribution_titles": null,
+                "dcat": {
+                    "@type": "dcat:Dataset",
+                    "title": "Inner",
+                    "keyword": null,
+                    "theme": null,
+                    "distribution": null,
+                    "language": null,
+                    "references": null
+                }
+            }],
+            "sort": "relevance"
+        })))
+        .mount(&server)
+        .await;
+
+    let client = client_for(&server);
+    let page = client
+        .search(SearchParams::new().q("anything"))
+        .await
+        .expect("null Vec fields should not panic on parse");
+    assert_eq!(page.results.len(), 1);
+    let hit = &page.results[0];
+    assert_eq!(hit.slug.as_deref(), Some("with-nulls"));
+    assert!(hit.keyword.is_empty());
+    assert!(hit.theme.is_empty());
+    assert!(hit.distribution_titles.is_empty());
+    let dcat = hit.dcat.as_ref().expect("dcat present");
+    assert!(dcat.keyword.is_empty());
+    assert!(dcat.theme.is_empty());
+    assert!(dcat.distribution.is_empty());
+    assert!(dcat.language.is_empty());
+    assert!(dcat.references.is_empty());
+}
+
 #[tokio::test]
 async fn locations_search_returns_suggestions() {
     let server = MockServer::start().await;


### PR DESCRIPTION
## Summary

Closes #40. `ls /epa` was failing with `invalid type: null, expected a sequence at line 1 column 113903`. The Catalog API returns explicit `null` for empty repeated DCAT-US 3 fields (e.g. `"references": null`), and `#[serde(default)]` doesn't cover that — it only handles *missing* fields, not present-with-null.

Add a `deserialize_null_as_default` helper and apply it to every `Vec<T>` field across `data-gov-catalog/src/models.rs` (13 sites). Pure defense — no behavior change for well-formed responses.

## Verified live

```
$ data-gov
cd /epa
OK Active context: /epa
ls
Fetching datasets in 'epa'...
Found 50 datasets in epa (more available — pagination not yet implemented):
 1. supply-chain-greenhouse-gas-emission-factors-v1-3-by-naics-6 ...
```

The offending dataset (#1, "Supply Chain Greenhouse Gas Emission Factors") parses cleanly now.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — catalog tests now 14 (was 13)
- [x] New regression test pins null-tolerance for top-level + nested Vec fields
- [x] Live: `ls /epa` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)