### PR TITLE
REPL pagination, richer ls output, lift search cap (closes #5, finishes #37)

### DIFF
--- a/data-gov/tools/cli/ui/commands.rs
+++ b/data-gov/tools/cli/ui/commands.rs
@@ -23,6 +23,8 @@ pub enum ReplCommand {
         /// lists that org's datasets, and at a dataset it lists distributions.
         what: Option<String>,
     },
+    /// Fetch the next page of the most recent listing or search.
+    Next,
     Select {
         path: String,
     },
@@ -34,11 +36,35 @@ pub enum ReplCommand {
     Quit,
 }
 
+/// Cursor describing what was last listed so a subsequent `next` knows
+/// what to advance.
+#[derive(Debug, Clone)]
+pub enum ListingCursor {
+    /// Datasets in `org`, paginated via `after`.
+    OrgDatasets {
+        org: String,
+        after: String,
+        page_size: i32,
+    },
+    /// Search results for `query` (optionally filtered by org), paginated
+    /// via `after`. Mirrors the args originally passed to `search`.
+    SearchResults {
+        query: String,
+        organization: Option<String>,
+        after: String,
+        page_size: i32,
+    },
+}
+
 /// Active session context set via `select /org/dataset`.
 #[derive(Debug, Clone, Default)]
 pub struct SessionContext {
     pub org: Option<String>,
     pub dataset: Option<String>,
+    /// Pagination cursor from the most recent listing or search. Populated
+    /// when the previous response carried an `after` cursor; consumed by
+    /// the `next` command.
+    pub last_listing: Option<ListingCursor>,
 }
 
 impl SessionContext {
@@ -235,6 +261,12 @@ impl ReplCommand {
                 })
             }
             "info" | "status" => Ok(ReplCommand::Info),
+            "next" | "n" | "more" => {
+                if parts.len() != 1 {
+                    return Err("Usage: next  (no arguments)".to_string());
+                }
+                Ok(ReplCommand::Next)
+            }
             "help" | "h" | "?" => Ok(ReplCommand::Help),
             "quit" | "exit" | "q" => Ok(ReplCommand::Quit),
             _ => Err(format!("Unknown command: {}", parts[0])),
@@ -397,6 +429,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: Some("air-quality".to_string()),
+            last_listing: None,
         };
         ctx.apply_navigate("/").unwrap();
         assert!(ctx.org.is_none());
@@ -409,6 +442,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("old-org".to_string()),
             dataset: Some("old-dataset".to_string()),
+            last_listing: None,
         };
         ctx.apply_navigate("/new-org/new-dataset").unwrap();
         assert_eq!(ctx.org, Some("new-org".to_string()));
@@ -420,6 +454,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("old-org".to_string()),
             dataset: Some("old-dataset".to_string()),
+            last_listing: None,
         };
         ctx.apply_navigate("/new-org").unwrap();
         assert_eq!(ctx.org, Some("new-org".to_string()));
@@ -441,6 +476,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: None,
+            last_listing: None,
         };
         ctx.apply_navigate("water-data").unwrap();
         assert_eq!(ctx.org, Some("epa-gov".to_string()));
@@ -452,6 +488,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: Some("air-quality".to_string()),
+            last_listing: None,
         };
         let result = ctx.apply_navigate("something");
         assert!(result.is_err());
@@ -463,6 +500,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: Some("air-quality".to_string()),
+            last_listing: None,
         };
         ctx.apply_navigate("..").unwrap();
         assert_eq!(ctx.org, Some("epa-gov".to_string()));
@@ -474,6 +512,7 @@ mod tests {
         let mut ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: None,
+            last_listing: None,
         };
         ctx.apply_navigate("..").unwrap();
         assert!(ctx.org.is_none());
@@ -503,6 +542,7 @@ mod tests {
         let ctx = SessionContext {
             org: Some("epa-gov".to_string()),
             dataset: Some("air-quality".to_string()),
+            last_listing: None,
         };
         assert_eq!(ctx.prompt_label(), "/epa-gov/air-quality");
     }
@@ -512,6 +552,7 @@ mod tests {
         let ctx = SessionContext {
             org: None,
             dataset: Some("orphan-ds".to_string()),
+            last_listing: None,
         };
         assert_eq!(ctx.prompt_label(), "//orphan-ds");
     }

--- a/data-gov/tools/cli/ui/display.rs
+++ b/data-gov/tools/cli/ui/display.rs
@@ -189,6 +189,11 @@ pub fn print_repl_help() {
             "ls",
         ),
         (
+            "next",
+            "Fetch the next page of the most recent search or ls (alias: 'n')",
+            "next",
+        ),
+        (
             "lcd <path>",
             "Set local download directory",
             "lcd ./downloads",

--- a/data-gov/tools/cli/ui/handlers.rs
+++ b/data-gov/tools/cli/ui/handlers.rs
@@ -3,7 +3,7 @@ use data_gov::catalog::models::Distribution;
 use data_gov::util::sanitize_path_component;
 use tokio::runtime::Runtime;
 
-use super::commands::{ReplCommand, SessionContext};
+use super::commands::{ListingCursor, ReplCommand, SessionContext};
 use super::display::{print_cli_help, print_package_details};
 use super::{
     color_blue, color_blue_bold, color_bold, color_cyan, color_dimmed, color_green,
@@ -57,6 +57,10 @@ pub fn execute_command(
             handle_list(client, rt, ctx, what.as_deref())?;
         }
 
+        ReplCommand::Next => {
+            handle_next(client, rt, ctx)?;
+        }
+
         ReplCommand::Select { path } => {
             handle_select(client, rt, ctx, &path)?;
         }
@@ -106,6 +110,7 @@ fn handle_select(
     let mut candidate = ctx.clone();
     candidate.apply_navigate(path)?;
     validate_candidate_exists(client, rt, &candidate)?;
+    candidate.last_listing = None;
     *ctx = candidate;
     print_select_result(ctx);
     Ok(())
@@ -152,6 +157,7 @@ fn resolve_single_segment_cd(
     if orgs.iter().any(|s| s == slug) {
         ctx.org = Some(slug.to_string());
         ctx.dataset = None;
+        ctx.last_listing = None;
         print_select_result(ctx);
         return Ok(());
     }
@@ -160,6 +166,7 @@ fn resolve_single_segment_cd(
         Ok(hit) => {
             ctx.org = hit.organization.as_ref().and_then(|o| o.slug.clone());
             ctx.dataset = Some(slug.to_string());
+            ctx.last_listing = None;
             print_select_result(ctx);
             Ok(())
         }
@@ -221,16 +228,25 @@ fn print_select_result(ctx: &SessionContext) {
     }
 }
 
-/// Handle search command.
+/// Default page size for `search` and `ls` listings when the user
+/// doesn't specify one. Each command's underlying API tops out around
+/// 1000 results per page; 50 is small enough to fit comfortably in a
+/// terminal viewport while still being useful for scripting.
+const DEFAULT_PAGE_SIZE: i32 = 50;
+
+/// Handle search command. Renders all returned hits (no artificial
+/// display cap), and stashes the next-page cursor on the session
+/// context so a subsequent `next` can advance.
 fn handle_search(
     client: &DataGovClient,
     rt: &Runtime,
     query: &str,
     limit: Option<i32>,
-    ctx: &SessionContext,
+    ctx: &mut SessionContext,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let org = ctx.org.as_deref();
-    if let Some(org_name) = org {
+    let org = ctx.org.clone();
+    let effective_limit = limit.unwrap_or(DEFAULT_PAGE_SIZE);
+    if let Some(org_name) = org.as_deref() {
         println!(
             "{} '{}' in org {}...",
             color_cyan("Searching for"),
@@ -241,25 +257,28 @@ fn handle_search(
         println!("{} '{}'...", color_cyan("Searching for"), query);
     }
 
-    let page = rt.block_on(client.search(query, limit, None, org))?;
-    let more_available = page.after.is_some();
-    let shown = page.results.len();
+    let page = rt.block_on(client.search(query, Some(effective_limit), None, org.as_deref()))?;
+    print_search_hits(&page.results);
+    summarize_listing(page.results.len(), page.after.as_deref(), "results");
 
-    if more_available {
-        println!(
-            "\n{} {} results on this page (more available):\n",
-            color_green_bold("Found"),
-            shown
-        );
-    } else {
-        println!("\n{} {} results:\n", color_green_bold("Found"), shown);
-    }
+    ctx.last_listing = page.after.map(|after| ListingCursor::SearchResults {
+        query: query.to_string(),
+        organization: org,
+        after,
+        page_size: effective_limit,
+    });
 
-    for (i, hit) in page.results.iter().enumerate().take(20) {
+    Ok(())
+}
+
+/// Render search hits in a compact list with an optional truncated
+/// description. Caller decides how many to show — there's no hard
+/// display cap.
+fn print_search_hits(hits: &[data_gov::catalog::models::SearchHit]) {
+    for hit in hits {
         let slug = hit.slug.as_deref().unwrap_or("(no-slug)");
         println!(
-            "{}. {} {}",
-            color_blue_bold(&format!("{:2}", i + 1)),
+            "{} {}",
             color_yellow_bold(slug),
             color_dimmed(hit.title.as_deref().unwrap_or(""))
         );
@@ -273,13 +292,78 @@ fn handle_search(
             };
             println!("   {}", color_dimmed(&truncated));
         }
-        println!();
     }
+}
 
-    if shown > 20 {
-        println!("... and {} more results on this page", shown - 20);
+/// Print the standard `Found N <unit>` line, with a `next` hint when
+/// more pages are available.
+fn summarize_listing(count: usize, after: Option<&str>, unit: &str) {
+    if after.is_some() {
+        println!(
+            "\n{} {} {} (type 'next' for more)",
+            color_green_bold("Found"),
+            count,
+            unit
+        );
+    } else {
+        println!("\n{} {} {}", color_green_bold("Found"), count, unit);
     }
+}
 
+/// Advance the most recent paginated listing by one page. Errors clearly
+/// when nothing has been listed yet (or when the previous listing was
+/// already on its last page).
+fn handle_next(
+    client: &DataGovClient,
+    rt: &Runtime,
+    ctx: &mut SessionContext,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cursor = ctx.last_listing.take().ok_or(
+        "nothing to continue — run a `search` or `ls` that reports 'more available' first",
+    )?;
+
+    match cursor {
+        ListingCursor::OrgDatasets {
+            org,
+            after,
+            page_size,
+        } => {
+            let page = rt.block_on(client.search(
+                "",
+                Some(page_size),
+                Some(after.as_str()),
+                Some(org.as_str()),
+            ))?;
+            print_dataset_hits(&page.results);
+            summarize_listing(page.results.len(), page.after.as_deref(), "more datasets");
+            ctx.last_listing = page.after.map(|after| ListingCursor::OrgDatasets {
+                org,
+                after,
+                page_size,
+            });
+        }
+        ListingCursor::SearchResults {
+            query,
+            organization,
+            after,
+            page_size,
+        } => {
+            let page = rt.block_on(client.search(
+                &query,
+                Some(page_size),
+                Some(after.as_str()),
+                organization.as_deref(),
+            ))?;
+            print_search_hits(&page.results);
+            summarize_listing(page.results.len(), page.after.as_deref(), "more results");
+            ctx.last_listing = page.after.map(|after| ListingCursor::SearchResults {
+                query,
+                organization,
+                after,
+                page_size,
+            });
+        }
+    }
     Ok(())
 }
 
@@ -541,12 +625,13 @@ fn print_download_summary(results: &[Result<std::path::PathBuf, data_gov::DataGo
 fn handle_list(
     client: &DataGovClient,
     rt: &Runtime,
-    ctx: &SessionContext,
+    ctx: &mut SessionContext,
     what: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if let Some(subject) = what {
         match subject.to_lowercase().as_str() {
             "organizations" | "orgs" => {
+                ctx.last_listing = None;
                 return list_organizations(client, rt);
             }
             other => {
@@ -558,9 +643,20 @@ fn handle_list(
     }
 
     match (&ctx.org, &ctx.dataset) {
-        (_, Some(slug)) => list_dataset_distributions(client, rt, slug),
-        (Some(org), None) => list_org_datasets(client, rt, org),
-        (None, None) => list_organizations(client, rt),
+        (_, Some(slug)) => {
+            // Distributions aren't paginated; the dataset record carries them all.
+            let slug = slug.clone();
+            ctx.last_listing = None;
+            list_dataset_distributions(client, rt, &slug)
+        }
+        (Some(org), None) => {
+            let org = org.clone();
+            list_org_datasets(client, rt, ctx, &org)
+        }
+        (None, None) => {
+            ctx.last_listing = None;
+            list_organizations(client, rt)
+        }
     }
 }
 
@@ -569,7 +665,9 @@ fn list_organizations(
     rt: &Runtime,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("{} organizations...", color_cyan("Fetching"));
-    let orgs = rt.block_on(client.list_organizations(Some(50)))?;
+    // The org list comes back as a single bulk response (~60-70 orgs);
+    // there's no API-level pagination, so show them all.
+    let orgs = rt.block_on(client.list_organizations(None))?;
     println!("\n{} organizations:", color_green_bold("Government"));
     for (i, org) in orgs.iter().enumerate() {
         println!(
@@ -584,12 +682,13 @@ fn list_organizations(
 fn list_org_datasets(
     client: &DataGovClient,
     rt: &Runtime,
+    ctx: &mut SessionContext,
     org: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("{} datasets in '{}'...", color_cyan("Fetching"), org);
-    // Empty query + organization filter = "all datasets in this org".
-    let page = rt.block_on(client.search("", Some(50), None, Some(org)))?;
+    let page = rt.block_on(client.search("", Some(DEFAULT_PAGE_SIZE), None, Some(org)))?;
     if page.results.is_empty() {
+        ctx.last_listing = None;
         println!(
             "{} No datasets found in '{}'.",
             color_yellow_bold("Note:"),
@@ -597,29 +696,50 @@ fn list_org_datasets(
         );
         return Ok(());
     }
-    let suffix = if page.after.is_some() {
-        " (more available — pagination not yet implemented)"
-    } else {
-        ""
-    };
-    println!(
-        "\n{} {} datasets in {}{}:",
-        color_green_bold("Found"),
-        page.results.len(),
-        color_yellow(org),
-        suffix
-    );
-    for (i, hit) in page.results.iter().enumerate() {
+    print_dataset_hits(&page.results);
+    summarize_listing(page.results.len(), page.after.as_deref(), "datasets");
+
+    ctx.last_listing = page.after.map(|after| ListingCursor::OrgDatasets {
+        org: org.to_string(),
+        after,
+        page_size: DEFAULT_PAGE_SIZE,
+    });
+    Ok(())
+}
+
+/// Render datasets as `<slug> — <title>` with a tiny "[N files, modified
+/// YYYY-MM-DD]" tail when those fields are populated. Distribution count
+/// and last-harvested date come from the search response, so no extra
+/// network call is needed.
+fn print_dataset_hits(hits: &[data_gov::catalog::models::SearchHit]) {
+    for hit in hits {
         let slug = hit.slug.as_deref().unwrap_or("(no-slug)");
         let title = hit.title.as_deref().unwrap_or("");
+
+        let mut tail_parts: Vec<String> = Vec::new();
+        let dist_count = hit.distribution_titles.len();
+        if dist_count > 0 {
+            let unit = if dist_count == 1 { "file" } else { "files" };
+            tail_parts.push(format!("{dist_count} {unit}"));
+        }
+        if let Some(date) = hit.last_harvested_date.as_deref() {
+            // Display just the date portion if it's an ISO timestamp.
+            let short = date.split('T').next().unwrap_or(date);
+            tail_parts.push(format!("modified {short}"));
+        }
+        let tail = if tail_parts.is_empty() {
+            String::new()
+        } else {
+            format!("  [{}]", tail_parts.join(", "))
+        };
+
         println!(
-            "{}. {} {}",
-            color_blue_bold(&format!("{:2}", i + 1)),
+            "{} {}{}",
             color_yellow_bold(slug),
-            color_dimmed(title)
+            color_dimmed(title),
+            color_dimmed(&tail),
         );
     }
-    Ok(())
 }
 
 fn list_dataset_distributions(


### PR DESCRIPTION
## Summary

Closes #5 (UI pagination) and finishes #37 (Unix-fs metaphor).

- **`next` REPL command** advances the most recent paginated listing or search. `SessionContext` carries a `ListingCursor` between commands; `search` and `ls /<org>` populate it, `cd` and non-paginated commands clear it.
- **Removed the 20-row display cap** in `search`. `search foo 25` previously fetched 25 and showed only 20; now everything in the response renders, and the `Found N results (type 'next' for more)` line tells you whether more pages exist.
- **Richer dataset listings** in `ls /<org>`: each entry now shows `[N files, modified YYYY-MM-DD]` when the search hit carries `distribution_titles` and/or `last_harvested_date`. Zero extra network cost — those fields come on the search response.
- Factored out `DEFAULT_PAGE_SIZE = 50` for `search`/`ls`. `list_organizations` now uses `None` for the limit (the API returns the full ~70-org list in one shot). Help text updated.

## Behavior

```
data-gov:/> cd /epa
OK Active context: /epa
data-gov:/epa> ls
... 50 EPA datasets ...
ambient-air-quality-data-inventory Ambient Air Quality Data Inventory  [modified 2025-07-31]
xrd-raw-data XRD Raw data  [1 file, modified 2026-04-21]
...
Found 50 datasets (type 'next' for more)
data-gov:/epa> next
... 50 more ...
Found 50 more datasets (type 'next' for more)
data-gov:/epa> search climate 25
... 25 results ...
Found 25 results (type 'next' for more)
data-gov:/epa> next
... 25 more ...
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — all green (tests in `commands.rs` updated for the new `last_listing` field)
- [x] Live: `ls` paginates via `next`; `search foo 25` shows all 25 + `next` works; dataset listings show `[N files, modified ...]` tail
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)