### PR TITLE
Document the REPL Unix-fs metaphor with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,30 @@ rustc --version  # should be 1.90 or newer
 cargo install data-gov
 ```
 
-Common commands:
+The REPL treats the data.gov catalog as a Unix-style filesystem
+(`/` → orgs → datasets → distributions). Quick tour:
+
+```
+$ data-gov
+data-gov:/> ls                      # list orgs
+data-gov:/> cd /epa                 # validated against the catalog
+data-gov:/epa> ls                   # 50 datasets, paginated
+data-gov:/epa> next                 # next page
+data-gov:/epa> cd integrated-risk-information-system-iris
+data-gov:/epa/iris> show .          # '.' = current dataset
+data-gov:/epa/iris> download 0      # zero-based, matches `ls`
+```
+
+Or use the same commands as one-shots from your shell:
 
 - `data-gov search "climate change" 10`
 - `data-gov show electric-vehicle-population-data`
-- `data-gov download electric-vehicle-population-data 0`                              # Download by index
-- `data-gov download electric-vehicle-population-data "Comma Separated Values File"`  # Download by title (quoted)
+- `data-gov download electric-vehicle-population-data 0`
+- `data-gov ls`
 - `data-gov list organizations`
+
+See [`data-gov/README.md`](./data-gov/README.md) for the full command
+reference and metaphor walkthrough.
 
 The CLI automatically adjusts colour and progress output for TTY / non-TTY environments. Tune behaviour with `--color`, `NO_COLOR`, or `NO_PROGRESS` as needed.
 
@@ -77,8 +94,9 @@ The binary doubles as an interactive REPL. You can automate workflows with sheba
 
 ```bash
 #!/usr/bin/env data-gov
-search climate 5
-download consumer-complaint-database 0
+cd /electric-vehicle-population-data
+show .
+download 0
 quit
 ```
 

--- a/data-gov/README.md
+++ b/data-gov/README.md
@@ -87,18 +87,83 @@ async fn main() -> data_gov::Result<()> {
 
 ## CLI overview
 
+The REPL treats the data.gov catalog as a four-level Unix-style filesystem:
+
+```
+/                           → root (organizations live here)
+/<org>/                     → an organization's datasets
+/<org>/<dataset>/           → a dataset's downloadable distributions
+```
+
+`cd` and `ls` work the way you'd expect from a shell. Every `cd` is
+validated against the catalog before adopting the new context, so a
+typo doesn't silently leave you in a bogus location.
+
+### REPL session walkthrough
+
+```
+$ data-gov
+🇺🇸 Data.gov Interactive Explorer
+
+data-gov:/> ls                              # list organizations
+ 1. census
+ 2. noaa
+ 3. epa
+ ...
+data-gov:/> cd /epa                         # validated against the org list
+OK Active context: /epa
+data-gov:/epa> ls                           # datasets in EPA, paginated 50 at a time
+ambient-air-quality-data-inventory  Ambient Air Quality Data Inventory  [modified 2025-07-31]
+xrd-raw-data  XRD Raw data  [1 file, modified 2026-04-21]
+...
+Found 50 datasets (type 'next' for more)
+data-gov:/epa> next                         # advance one page
+... 50 more datasets ...
+data-gov:/epa> cd integrated-risk-information-system-iris
+OK Active context: /epa/integrated-risk-information-system-iris
+data-gov:/epa/integrated-risk-information-system-iris> ls    # distributions
+ 0. (untitled) [text/csv]
+ 1. (untitled) [application/json]
+data-gov:/epa/integrated-risk-information-system-iris> show .   # '.' = current dataset
+... dataset details ...
+data-gov:/epa/integrated-risk-information-system-iris> download 0
+... downloads distribution[0] ...
+data-gov:/epa/integrated-risk-information-system-iris> cd ..
+OK Active context: /epa
+```
+
+Notes on the metaphor:
+
+- `cd /<single-segment>` resolves as either an org *or* a dataset slug —
+  data.gov has a flat slug namespace, so the REPL tries org first and
+  falls back to dataset. When a single segment matches a dataset, the
+  org context is auto-populated from the dataset's publisher.
+- `cd ..` walks up one level. `cd /` returns to root.
+- `.` always means "the current dataset" in commands that take a slug
+  (e.g. `show .`, where supported). Errors clearly when nothing is
+  selected.
+- Distribution indexes in `ls` are zero-based and match what `download N`
+  expects — no off-by-one between displayed and addressable indexes.
+- `next` advances the most recent paginated `search` or `ls`. `cd` clears
+  the cursor (so a stale `next` doesn't reach back into the previous
+  location).
+
+### One-shot CLI usage
+
+The same commands work as one-shot invocations from your shell:
+
 ```
 data-gov search "climate change" 5
 data-gov show electric-vehicle-population-data
-data-gov download electric-vehicle-population-data 0                                 # Download by index
-data-gov download electric-vehicle-population-data "Comma Separated Values File"    # Download by title (quoted)
-data-gov download electric-vehicle-population-data csv                               # Partial title match
-data-gov list organizations
+data-gov download electric-vehicle-population-data 0                                 # by index
+data-gov download electric-vehicle-population-data "Comma Separated Values File"    # by title (quoted)
+data-gov download electric-vehicle-population-data csv                               # partial title match
+data-gov ls                                                                          # at root, lists orgs
 ```
 
 Key defaults:
 
-- **Interactive mode:** `data-gov` launches a REPL that stores downloads under `~/Downloads/<dataset>/`
+- **Interactive mode:** `data-gov` launches the REPL and stores downloads under `~/Downloads/<dataset>/`
 - **Non-interactive mode:** Commands run directly in your current directory (`./<dataset>/`)
 - Override download location with `--download-dir`, toggle colours with `--color`, and silence progress bars via `NO_PROGRESS=1`
 
@@ -106,12 +171,15 @@ Key defaults:
 
 | Command | Purpose |
 | ------- | ------- |
-| `search <query> [limit]` | Full-text search with optional page size |
-| `show <dataset_slug>` | Inspect dataset details and distributions |
-| `download <dataset_slug> [index\|title]` | Download all distributions, or specific ones by index or title substring |
-| `list organizations` | List publishing organisations |
-| `setdir <path>` | Change the active download directory (REPL only) |
-| `info` | Display current configuration |
+| `cd <path>` | Navigate to an org or dataset (validated). Examples: `cd /epa`, `cd /epa/air-quality-data`, `cd ..`, `cd /` |
+| `ls` | List the contents of the current location (orgs at `/`, datasets at `/<org>`, distributions at `/<org>/<dataset>`). Paginated 50 at a time |
+| `next` (alias `n`) | Fetch the next page of the most recent `ls` or `search` |
+| `search <query> [limit]` | Full-text search; honors active org filter; results paginate via `next` |
+| `show [dataset_slug\|.]` | Show dataset info; `.` or omitted means the current dataset |
+| `download [dataset_slug] [selectors...]` | Download distributions by zero-based index or title substring; with no selectors, downloads all |
+| `list organizations` | Bulk org list (regardless of context) |
+| `lcd <path>` | Change the active download directory (REPL only) |
+| `info` | Display current session and client configuration |
 | `help`, `quit` | Help and exit commands |
 
 ### Automation
@@ -121,9 +189,12 @@ The REPL accepts stdin, so shebang scripts work out of the box:
 ```bash
 #!/usr/bin/env data-gov
 # Simple automation example
+cd /epa
+ls
 search "electric vehicle" 3
-show electric-vehicle-population-data
-download electric-vehicle-population-data "Comma Separated Values File"    # Download by title (quoted)
+cd /electric-vehicle-population-data
+show .
+download 0
 quit
 ```
 
@@ -131,9 +202,9 @@ See [`../examples/scripting`](../examples/scripting) for ready-made scripts such
 
 ### Pagination
 
-The Catalog API uses cursor-based pagination. The search response carries an
-`after` field when more pages are available; pass it back on the next call to
-advance:
+In the REPL, `search` and `ls` results paginate automatically — type `next`
+(or `n`) to advance, and the previous-page cursor is forgotten when you `cd`.
+Programmatically, the underlying client uses cursor-based pagination:
 
 ```rust
 let page1 = client.search("climate", Some(20), None, None).await?;

--- a/examples/scripting/README.md
+++ b/examples/scripting/README.md
@@ -38,18 +38,39 @@ data-gov < script-name.sh
 1. Start with the shebang line: `#!/usr/bin/env data-gov`
 2. Add comments to describe what the script does
 3. Use any combination of data-gov commands:
-   - `search <query> [limit]`
-   - `show <dataset-id>`
-   - `download <dataset-id> [resource-index]`
-   - `list organizations`
-   - `info`
+   - `cd <path>` — navigate (`/`, `/<org>`, `/<org>/<dataset>`, or just `/<dataset>`; validated against the catalog)
+   - `ls` — list contents of the current location
+   - `next` (or `n`) — fetch the next page of the most recent `search` or `ls`
+   - `search <query> [limit]` — full-text search (filtered by active org if any)
+   - `show [dataset_slug|.]` — show dataset details (`.` = current)
+   - `download [dataset_slug] [selectors...]` — download by zero-based index or title substring
+   - `list organizations` — bulk org list (regardless of context)
+   - `info`, `help`, `quit`
 4. End with `quit` to cleanly exit
 5. Make executable with `chmod +x script.sh`
 
-Example:
+The REPL treats the data.gov catalog as a four-level Unix-style
+filesystem: root → organizations → datasets → distributions. `cd` and
+`ls` work the way you'd expect from a shell, and `cd` validates each
+path against the catalog before adopting it, so a typo errors loudly
+instead of leaving you in a bogus location.
+
+Example using the unix-fs idiom:
+
 ```bash
 #!/usr/bin/env data-gov
-# My custom data script
+# Navigate into a dataset, list its distributions, download the first one.
+cd /electric-vehicle-population-data
+ls
+download 0
+quit
+```
+
+Example using the legacy one-shot idiom (still supported):
+
+```bash
+#!/usr/bin/env data-gov
+# Search and download in flat command form.
 search "my topic" 5
 show first-dataset-id
 download first-dataset-id 0


### PR DESCRIPTION
## Summary

The cd/ls/next/`.` work has been shipped (#38, #42), but the READMEs were stuck on the pre-metaphor flow. Built-in `help` was the only place that documented the new commands. This PR fixes that.

## Changes

- **`data-gov/README.md`** — rewrite the CLI overview to lead with the filesystem metaphor; add a session walkthrough; expand the command reference table to cover `cd`, `ls`, `next`, and update changed entries (`show [.|slug]`, `download` with selectors); pagination section now describes both REPL `next` and the library-level cursor pattern; automation example uses the new idioms.
- **Workspace `README.md`** — quick REPL tour at the top of the CLI install section; updated shebang script example.
- **`examples/scripting/README.md`** — list the new commands available in scripts; one-paragraph explanation of the metaphor; show both unix-fs and legacy one-shot script idioms.

## Test plan

- [x] `cargo fmt`, `clippy`, `test` all pass (no code touched, but verifying nothing else regressed)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)