### PR TITLE
ci: run the whole test suite, and run it on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'release/**' ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,13 +22,13 @@ jobs:
           - 1.90.0  # MSRV
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.rust }}
         components: rustfmt, clippy
-    
+
     - name: Cache cargo
       uses: actions/cache@v4
       with:
@@ -39,86 +40,33 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-cargo-${{ matrix.rust }}-
           ${{ runner.os }}-cargo-
-    
+
     - name: Check formatting
       run: cargo fmt --all -- --check
       if: matrix.rust == 'stable'
-    
+
     - name: Run clippy
       run: cargo clippy --all-targets --all-features -- -D warnings
       if: matrix.rust == 'stable'
-    
+
     - name: Build
-      run: cargo build --verbose --all-features
-    
-    - name: Run unit tests
-      run: cargo test --verbose --lib --all-features
-    
-    - name: Run doc tests
-      run: cargo test --verbose --doc --all-features
+      run: cargo build --verbose --all-features --workspace
 
-  integration-test:
-    name: Integration Tests
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-    
-    - name: Cache cargo
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
-    
-    - name: Run integration tests
-      run: |
-        cd data-gov-ckan
-        cargo test --test integration_tests --verbose
-      env:
-        # Add any API keys or config needed for integration tests
-        RUST_LOG: debug
-        # CKAN_API_KEY: ${{ secrets.CKAN_API_KEY }}  # If you have API keys
-
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-    
-    - name: Cache cargo
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
-    
-    - name: Build documentation
-      run: cargo doc --verbose --all-features --no-deps --document-private-items
-    
-    - name: Check documentation coverage
-      run: |
-        cargo install cargo-doc-coverage || true
-        cargo doc-coverage --output-format json | jq '.coverage_percentage'
+    # --workspace --all-targets covers unit tests, every tests/ integration
+    # target, and doc tests. Selecting --lib here would silently skip both
+    # binary crates and every tests/ target: 37 of 181 tests would run.
+    - name: Run tests
+      run: cargo test --verbose --all-features --workspace
 
   examples:
     name: Examples
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
-    
+
     - name: Cache cargo
       uses: actions/cache@v4
       with:
@@ -127,24 +75,41 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-examples-${{ hashFiles('**/Cargo.lock') }}
-    
+
+    # Examples make real API calls, so they are compiled but not run.
     - name: Build examples
-      run: |
-        cd data-gov-ckan
-        cargo build --examples --verbose
-    
-    # Note: We don't run examples in CI since they make real API calls
-    # But we ensure they compile properly
+      run: cargo build --examples --workspace --all-features --verbose
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build documentation
+      run: cargo doc --verbose --all-features --no-deps --document-private-items
 
   security:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
-    
+
     - name: Cache cargo
       uses: actions/cache@v4
       with:
@@ -153,9 +118,44 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-audit-${{ hashFiles('**/Cargo.lock') }}
-    
+
     - name: Install cargo-audit
-      run: cargo install cargo-audit
-    
-    - name: Run security audit
+      run: cargo install cargo-audit --locked
+
+    - name: Run cargo audit (RustSec advisory database)
       run: cargo audit
+
+    # cargo audit only consults the RustSec database. Seven openssl advisories
+    # (five High) were GHSA-only and invisible to it; OSV.dev aggregates both,
+    # so this step is not redundant with the one above.
+    - name: Scan lockfile against OSV (catches GHSA-only advisories)
+      uses: google/osv-scanner-action@v2.3.8
+      with:
+        scan-args: |-
+          --lockfile=./Cargo.lock
+
+  live-api:
+    name: Live API Tests
+    # Hits the real data.gov Catalog API, so it is opt-in rather than gating:
+    # a data.gov outage must not turn PRs red. Run it from the Actions tab.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache cargo
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-live-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Run ignored (network) tests
+      run: cargo test --verbose --all-features --workspace -- --ignored
+      env:
+        RUST_LOG: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,13 @@ jobs:
     # cargo audit only consults the RustSec database. Seven openssl advisories
     # (five High) were GHSA-only and invisible to it; OSV.dev aggregates both,
     # so this step is not redundant with the one above.
+    #
+    # The action lives in a subdirectory: the repository root action.yml carries
+    # only branding metadata and has no `runs:` block, so referencing the repo
+    # root fails at job setup. Pin the exact patch version — upstream notes the
+    # scanner action's behaviour may change within a minor release.
     - name: Scan lockfile against OSV (catches GHSA-only advisories)
-      uses: google/osv-scanner-action@v2.3.8
+      uses: google/osv-scanner-action/osv-scanner-action@v2.3.8
       with:
         scan-args: |-
           --lockfile=./Cargo.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - Unreleased
 
-Release in progress. Entries are added here as work merges into `release/0.5.0`.
+### Infrastructure
+
+- **CI now runs 181 tests instead of 37** (#23). The gate selected `--lib`,
+  which skips both binary crates (`data-gov-mcp-server` has no `lib.rs`; the
+  CLI is a `[[bin]]`) and every `tests/` integration target — so all 54
+  MCP-server tests, all 42 CLI tests, all 7 download tests, and all 14 catalog
+  wiremock tests never ran. `clippy --all-targets` compiled them, which is why
+  the gap was invisible.
+- **CI now runs on `release/**` branches** (#23). Triggers were limited to
+  `main`, so pull requests targeting a release branch received no checks at all.
+- **Replaced the permanently-green integration job** (#23). It ran
+  `cargo test --test integration_tests` in `data-gov-ckan`, where all 17 tests
+  are `#[ignore]`d — reporting success having executed nothing. Network tests
+  now live in an opt-in `workflow_dispatch` job that runs `-- --ignored`, so a
+  data.gov outage cannot turn pull requests red.
+- **Examples are compiled workspace-wide** (#25). The job built only
+  `data-gov-ckan`'s examples, leaving `data-gov/examples/demo.rs` uncompiled.
+- **Removed the no-op documentation-coverage step** (#25). It took its exit
+  status from `jq`, which succeeds on empty input, and compared the reported
+  percentage against no threshold — it could not fail. Enforcement moves to a
+  `missing_docs` lint once the outstanding gaps are documented (#59).
+- **Added an OSV/GHSA lockfile scan** alongside `cargo audit` (#46). The seven
+  `openssl` advisories were GHSA-only and invisible to `cargo audit`.
 
 ## [0.4.0] - 2026-04-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -373,15 +373,31 @@ Before any release:
 
 ## CI pipeline
 
-GitHub Actions CI (`.github/workflows/ci.yml`) runs:
+GitHub Actions CI (`.github/workflows/ci.yml`) runs on pushes and pull requests
+targeting `main` **and any `release/**` branch**, so release-branch work is gated
+the same way `main` is.
 
-1. **Format check** (`cargo fmt`, stable only)
+**Test Suite** (matrix: stable, beta, MSRV 1.90)
+1. **Format check** (`cargo fmt --all -- --check`, stable only)
 2. **Clippy** with `-D warnings` (stable only)
-3. **Build** on stable, beta, and MSRV 1.90
-4. **Unit tests** (`--lib`)
-5. **Doc tests** (`--doc`)
-6. **Integration tests** (separate job, stable only)
-7. **Documentation build**
-8. **Security audit** (`cargo audit`)
+3. **Build** (`--all-features --workspace`)
+4. **Tests** (`cargo test --all-features --workspace`)
 
-All checks must pass before merging to `main`.
+Test selection matters here. `--workspace` covers unit tests, every `tests/`
+integration target, and doc tests. Selecting `--lib` instead silently skips both
+binary crates (`data-gov-mcp-server` has no `lib.rs`; the CLI is a `[[bin]]`) and
+every `tests/` target — 37 of 181 tests would run, while `clippy --all-targets`
+still compiles the rest so nothing looks wrong. Do not narrow this back.
+
+**Other jobs**
+5. **Examples** — compiles all workspace examples (they make real API calls, so
+   they are built but never run)
+6. **Documentation build** (`cargo doc --no-deps`)
+7. **Security audit** — `cargo audit` *plus* an OSV/GHSA lockfile scan. Both are
+   required; see the dependency-freshness section for why `cargo audit` alone is
+   insufficient.
+8. **Live API Tests** — opt-in via `workflow_dispatch`, runs the `#[ignore]`d
+   network tests. Deliberately not gating: a data.gov outage must not turn PRs
+   red.
+
+All gating checks must pass before merging.


### PR DESCRIPTION
Targets `release/0.5.0`, not `main`.

## Two independent holes in the gate

**1. It ran 37 of 181 tests.** The step was `cargo test --lib`, and `--lib` selects only `lib.rs` targets. `data-gov-mcp-server` is bin-only with no `lib.rs`, and the `data-gov` CLI is a `[[bin]]` at `tools/cli/main.rs`, so neither contributed a single test. Every `tests/` integration target was excluded too.

Never executed in CI:

| Suite | Tests |
|---|---|
| `data-gov-mcp-server` | 54 |
| `data-gov` CLI | 42 |
| `data-gov-catalog` wiremock fixtures | 14 |
| `data-gov/tests/download_tests.rs` | 7 |
| …plus the rest of the `tests/` targets | |

`clippy --all-targets` compiles all of it, which is exactly why this stayed invisible — everything built, nothing ran. This is why the arbitrary-file-write defect (#45) shipped in published 0.4.0 with a green suite.

**2. CI never ran on release branches.** Triggers were `branches: [main]` for both `push` and `pull_request`. PR #79 against `release/0.5.0` reports `no checks reported`. The release-branch workflow was completely unprotected.

```
test:      --lib + --doc  ->  --all-features --workspace   (37 -> 181)
triggers:  main           ->  main + release/**
```

## Other jobs

- **Integration Tests → Live API Tests.** It ran `cargo test --test integration_tests` in `data-gov-ckan`, where all 17 tests are `#[ignore]`d: `0 passed; 17 ignored`, permanently green having executed nothing. Network tests now sit in an opt-in `workflow_dispatch` job running `-- --ignored`. Deliberately non-gating — a data.gov outage should not redden unrelated PRs.
- **Examples** built only `data-gov-ckan`; `data-gov/examples/demo.rs` was never compiled. Now workspace-wide (3 targets).
- **Doc-coverage step removed.** `cargo doc-coverage ... | jq '.coverage_percentage'` took its exit status from `jq`, which succeeds on empty input, and compared the number against no threshold. It could not fail. Real enforcement belongs in a `missing_docs` lint, which has to wait for #59 to document the gaps — turning it on now would just break the build.
- **OSV/GHSA scan added** beside `cargo audit`, pinned to `google/osv-scanner-action@v2.3.8`. This closes the acceptance item from #46 that PR #79 did not cover: the seven `openssl` advisories were GHSA-only and `cargo audit` never saw them.

## Verification

YAML parsed and every command run locally: build, workspace examples build, and `cargo test --all-features --workspace` → **181 passed, 0 failed**. Gate green: fmt, clippy `-D warnings`, tests, docs.

`CLAUDE.md`'s CI section is updated to match, including a note explaining why the test selection must not be narrowed back to `--lib`.

## Note

This branch is cut from `release/0.5.0`, so it does not include #79. Both touch `CHANGELOG.md` under `[0.5.0]`; expect a trivial conflict on whichever merges second.

Closes #23
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNz3zUgD2n8ckZkCTfdx8