### PR TITLE
docs: require breaking and behaviour changes at the top of the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
 0.4.0; both are recorded below.
 
 ### Breaking — Catalog API migration
-
 - **data.gov retired its CKAN Action API.** The workspace now targets the new
   [Catalog API](https://resources.data.gov/catalog-api/) (cursor-paginated,
   DCAT-US 3 payloads, no API keys).
@@ -51,26 +50,7 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
   `distributionIndexes`; the `formats` filter is now matched client-side
   against both `format` and `mediaType`.
 
-### Added — data-gov-catalog crate
-
-- **`data-gov-catalog`** — new crate wrapping the Catalog API with typed
-  models for DCAT-US 3 (`Dataset`, `Distribution`, `Publisher`,
-  `ContactPoint`), search envelopes (`SearchResponse`, `SearchHit`),
-  organizations, keywords, locations, and harvest records. Endpoint coverage:
-  `/search` (with `SearchParams` builder), `/api/organizations`,
-  `/api/keywords`, `/api/locations/search`, `/api/location/{id}`,
-  `/harvest_record/{id}`, `/harvest_record/{id}/raw`,
-  `/harvest_record/{id}/transformed`.
-
-### Deprecated
-
-- **`data-gov-ckan`** crate-level docs and README now note that data.gov no
-  longer uses CKAN. The crate remains published and functional for use against
-  other CKAN-compatible instances (European, state, municipal, university
-  portals).
-
 ### Breaking — reqwest 0.13 and client construction
-
 - **Removed `Default` impl for `DataGovClient`** — use `DataGovClient::new()?`
   instead. The previous impl could panic if the HTTP client failed to build.
 - **Upgraded reqwest from 0.12 to 0.13** across `data-gov-ckan` and `data-gov`.
@@ -82,8 +62,36 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
 - Default user-agent string now reflects the actual crate version
   (`data-gov-rs/0.4.0`) instead of the previously hardcoded `data-gov-rs/1.0`.
 
-### Added — tests, tooling, and utilities
+### Changed
+- **CKAN client refactored** — extracted `call_action<T>` generic helper,
+  reducing `client.rs` from ~1243 to ~771 lines and eliminating 10 copies of
+  HTTP boilerplate. Uses reqwest's `.query()` instead of manual URL encoding,
+  removing the `urlencoding` dependency.
+- **MCP server tool specs** — converted from a function returning `Vec<ToolSpec>`
+  to a `static TOOL_SPECS: LazyLock<Vec<ToolSpec>>` (allocated once).
+- **JSON-RPC version validation** — the MCP server now rejects requests where
+  `jsonrpc` is present but not `"2.0"`.
+- **CLI version** — now uses `env!("CARGO_PKG_VERSION")` instead of hardcoded
+  `"1.0"`.
+- **`download-dir` CLI flag** — removed magic string default detection;
+  the flag is now purely optional.
+- Path sanitization logic deduplicated into `data_gov::util`.
+- **MCP server modularized** — split monolithic `server.rs` (1548 lines) into
+  four focused modules: `server.rs` (run loop), `types.rs` (request/response
+  types and param structs), `tools.rs` (tool specs and lookup), `handlers.rs`
+  (method dispatch and handler logic).
 
+### Added — data-gov-catalog crate
+- **`data-gov-catalog`** — new crate wrapping the Catalog API with typed
+  models for DCAT-US 3 (`Dataset`, `Distribution`, `Publisher`,
+  `ContactPoint`), search envelopes (`SearchResponse`, `SearchHit`),
+  organizations, keywords, locations, and harvest records. Endpoint coverage:
+  `/search` (with `SearchParams` builder), `/api/organizations`,
+  `/api/keywords`, `/api/locations/search`, `/api/location/{id}`,
+  `/harvest_record/{id}`, `/harvest_record/{id}/raw`,
+  `/harvest_record/{id}/transformed`.
+
+### Added — tests, tooling, and utilities
 - **Comprehensive test suite** — 130+ tests across the workspace:
   - 21 wiremock-based unit tests for all CKAN client endpoints
     (`data-gov-ckan/tests/unit_tests.rs`)
@@ -103,7 +111,6 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
 - `Cargo.lock` is now committed for reproducible binary builds.
 
 ### Fixed
-
 - **Parallel download progress bars** — replaced independent `ProgressBar`
   instances with `indicatif::MultiProgress` so concurrent downloads render
   correctly instead of overwriting each other.
@@ -119,28 +126,13 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
   constructed once before the download loop; only `downloaded_bytes` is updated
   per chunk.
 
-### Changed
-
-- **CKAN client refactored** — extracted `call_action<T>` generic helper,
-  reducing `client.rs` from ~1243 to ~771 lines and eliminating 10 copies of
-  HTTP boilerplate. Uses reqwest's `.query()` instead of manual URL encoding,
-  removing the `urlencoding` dependency.
-- **MCP server tool specs** — converted from a function returning `Vec<ToolSpec>`
-  to a `static TOOL_SPECS: LazyLock<Vec<ToolSpec>>` (allocated once).
-- **JSON-RPC version validation** — the MCP server now rejects requests where
-  `jsonrpc` is present but not `"2.0"`.
-- **CLI version** — now uses `env!("CARGO_PKG_VERSION")` instead of hardcoded
-  `"1.0"`.
-- **`download-dir` CLI flag** — removed magic string default detection;
-  the flag is now purely optional.
-- Path sanitization logic deduplicated into `data_gov::util`.
-- **MCP server modularized** — split monolithic `server.rs` (1548 lines) into
-  four focused modules: `server.rs` (run loop), `types.rs` (request/response
-  types and param structs), `tools.rs` (tool specs and lookup), `handlers.rs`
-  (method dispatch and handler logic).
+### Deprecated
+- **`data-gov-ckan`** crate-level docs and README now note that data.gov no
+  longer uses CKAN. The crate remains published and functional for use against
+  other CKAN-compatible instances (European, state, municipal, university
+  portals).
 
 ### Removed
-
 - `urlencoding` dependency from `data-gov-ckan`.
 - `extern crate` declarations from `data-gov-ckan/src/lib.rs` (unnecessary
   since Rust 2018).
@@ -148,7 +140,6 @@ The Catalog API migration and the reqwest 0.13 upgrade shipped together in
   imports cleaned up.
 
 ### Infrastructure
-
 - Updated `actions/cache` from v3 to v4 in CI and release workflows.
 - Replaced deprecated `actions/create-release@v1` with
   `softprops/action-gh-release@v2` in release workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -266,10 +266,36 @@ changes, CLI or MCP surface changes — **adds an entry under the current
 `## [X.Y.Z] - Unreleased` heading in the same PR that makes the change.** Purely
 internal refactors with no observable effect may be omitted.
 
-Group entries under `Breaking`, `Added`, `Fixed`, `Changed`, `Removed`,
-`Deprecated`, or `Infrastructure`. Reference the issue number where one exists.
-On release, replace `- Unreleased` with the release date and open a fresh
-`## [X.Y.Z] - Unreleased` heading above it.
+#### Section order is mandatory
+
+**`Breaking` comes first, `Changed` second, always.** These are the two
+categories that cost a reader real money if missed — one stops their build, the
+other silently alters what their working code does — so they must never be
+buried beneath a list of additions and fixes. Within a release, sections appear
+in exactly this order, omitting any that are empty:
+
+| Order | Section | What belongs here |
+|-------|-----------------|-------------------------------------------------------------|
+| 1 | `Breaking` | Anything requiring a consumer to change their code to compile: removed or renamed public items, changed signatures or field types, altered feature or wire formats. **Removing public API is `Breaking`, not `Removed`.** |
+| 2 | `Changed` | Behaviour changes that still compile: different defaults, different output, different ordering, a fix that alters an existing contract. The dangerous ones — call these out even when they look minor. |
+| 3 | `Security` | Advisories cleared and vulnerabilities fixed. Name the CVE/RUSTSEC/GHSA ID. |
+| 4 | `Added` | New APIs, features, flags, tools. |
+| 5 | `Fixed` | Bugs fixed without changing an intended contract. |
+| 6 | `Deprecated` | Still present, slated for removal. Say what replaces it. |
+| 7 | `Removed` | Non-API removals only: dependencies, internal machinery, dead files. |
+| 8 | `Infrastructure` | CI, build, tooling. No consumer impact. |
+
+Where a single release has several distinct breaking themes, use qualified
+headings (`### Breaking — Catalog API migration`) and keep them adjacent at the
+top rather than scattering them.
+
+Each `Breaking` and `Changed` entry states **what a consumer must do**, not only
+what changed. `download_resources` renamed to `download_distributions` is a fact;
+"rename your calls, and pass `&[Distribution]` instead of `&[Resource]`" is
+actionable.
+
+Reference the issue number where one exists. On release, replace `- Unreleased`
+with the release date and open a fresh `## [X.Y.Z] - Unreleased` heading above it.
 
 ### Dependency freshness and advisories
 


### PR DESCRIPTION
Targets `release/0.5.0`.

## Rule

`Breaking` first, `Changed` second, always. Those are the two categories that cost a reader real money when missed — one stops their build, the other silently alters what their working code does — so they must not sit below a list of additions and fixes.

`CLAUDE.md` now mandates a fixed section order: **Breaking → Changed → Security → Added → Fixed → Deprecated → Removed → Infrastructure**, omitting empty ones.

Two consequences worth stating explicitly, both now in the rule:

- **Removing public API is `Breaking`, not `Removed`.** `Removed` is for dependencies, internal machinery, and dead files — things with no consumer impact. This distinction is easy to get wrong and it is exactly the case where getting it wrong buries the important entry.
- **`Breaking` and `Changed` entries say what the consumer must do.** "`download_resources` renamed to `download_distributions`" is a fact; "rename your calls, and pass `&[Distribution]` instead of `&[Resource]`" is actionable.

Where one release has several distinct breaking themes, use qualified headings (`### Breaking — Catalog API migration`) kept adjacent at the top rather than scattered.

## Applied to 0.4.0

That release had a real instance of the problem: its second breaking section — the reqwest 0.13 upgrade and the removed `Default` impl for `DataGovClient` — sat below `Added` and `Deprecated`, where an upgrader scanning the top of the entry would miss it.

```
before                                    after
  Breaking — Catalog API migration          Breaking — Catalog API migration
  Added — data-gov-catalog crate            Breaking — reqwest 0.13 and client construction
  Deprecated                                Changed
  Breaking — reqwest 0.13 …    <-- buried   Added — data-gov-catalog crate
  Added — tests, tooling …                  Added — tests, tooling, and utilities
  Fixed                                     Fixed
  Changed                                   Deprecated
  Removed                                   Removed
  Infrastructure                            Infrastructure
```

Content is unchanged — all 47 bullets preserved, verified by count.

## Note

Deliberately does not touch the `[0.5.0]` section, which is still in flux across #79 and #80. Those two will be ordered to this rule as they merge. Expect a small `CLAUDE.md` conflict with #80, which edits a different subsection of the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNz3zUgD2n8ckZkCTfdx8