### PR TITLE
fix(mcp): return protocolVersion from initialize and stop writing to stdout early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - Unreleased
 
+### Breaking
+
+- **MCP `initialize` now returns the required `protocolVersion`** and negotiates
+  it (#44). The server advertises `2024-11-05`, `2025-03-26`, `2025-06-18`, and
+  `2025-11-25`: a version it supports is echoed verbatim, anything else (or an
+  omitted field) gets `2025-11-25`. Previously the field was absent entirely, so
+  any client validating the result against the MCP schema aborted the handshake
+  and no tool was ever reachable.
+- **`capabilities.tools` now uses `listChanged`, not `list`** (#44). `list` is
+  not a key in the MCP schema. If you were reading `capabilities.tools.list`,
+  read `capabilities.tools.listChanged` instead — it is `false`, since the tool
+  list is static.
+- **The unsolicited `ready` line on stdout is gone** (#29). The server previously
+  wrote `{"jsonrpc":"2.0","id":null,"result":{...}}` before any request, which
+  matches no MCP message shape and is not valid JSON-RPC either — a `result`
+  response with a null id corresponds to no request. stdout is now silent until
+  the server answers a request. If you were parsing that line for the method
+  list, call `tools/list` after `initialize` instead. The same information still
+  goes to stderr via `tracing` at startup.
+
 ### Changed
 
 - All dependencies refreshed to their latest semver-compatible releases.

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -17,7 +17,7 @@ use wiremock::matchers::{method as wm_method, path as wm_path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::server::DataGovMcpServer;
-use crate::types::ServerError;
+use crate::types::{LATEST_PROTOCOL_VERSION, ServerError};
 
 /// Build a `DataGovMcpServer` whose internal client points at the given mock
 /// URL. Callers mount `Mock`s on the same server before exercising a dispatch
@@ -256,8 +256,100 @@ async fn dispatch_initialize_returns_raw_response() {
         "initialize is not a tool — must not be wrapped"
     );
     assert!(
-        result.get("serverInfo").is_some() || result.get("protocolVersion").is_some(),
-        "initialize result should carry server metadata, got: {result}"
+        result.get("serverInfo").is_some(),
+        "initialize result should carry serverInfo, got: {result}"
+    );
+    assert!(
+        result.get("protocolVersion").is_some(),
+        "initialize result must carry protocolVersion (MCP requires it), got: {result}"
+    );
+}
+
+/// The server must echo back a protocol version it supports when the client
+/// asks for one it knows.
+#[tokio::test]
+async fn initialize_echoes_a_supported_protocol_version() {
+    let server = test_server("http://127.0.0.1:1");
+    let result = server
+        .dispatch(
+            "initialize",
+            Some(json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": { "name": "test-client", "version": "0.0.0" }
+            })),
+        )
+        .await
+        .expect("initialize should succeed");
+
+    assert_eq!(
+        result.get("protocolVersion").and_then(|v| v.as_str()),
+        Some("2025-06-18"),
+        "a supported version must be echoed verbatim, got: {result}"
+    );
+}
+
+/// When the client asks for a version we do not know, the spec says to reply
+/// with another version we support -- the latest -- not to error or echo.
+#[tokio::test]
+async fn initialize_falls_back_to_latest_for_unknown_protocol_version() {
+    let server = test_server("http://127.0.0.1:1");
+    let result = server
+        .dispatch(
+            "initialize",
+            Some(json!({
+                "protocolVersion": "1999-01-01",
+                "clientInfo": { "name": "test-client", "version": "0.0.0" }
+            })),
+        )
+        .await
+        .expect("initialize should succeed");
+
+    assert_eq!(
+        result.get("protocolVersion").and_then(|v| v.as_str()),
+        Some(LATEST_PROTOCOL_VERSION),
+        "an unknown version must fall back to our latest, got: {result}"
+    );
+}
+
+/// A client that omits protocolVersion entirely still gets a usable answer.
+#[tokio::test]
+async fn initialize_without_a_requested_version_returns_latest() {
+    let server = test_server("http://127.0.0.1:1");
+    let result = server
+        .dispatch("initialize", Some(json!({})))
+        .await
+        .expect("initialize should succeed");
+
+    assert_eq!(
+        result.get("protocolVersion").and_then(|v| v.as_str()),
+        Some(LATEST_PROTOCOL_VERSION),
+        "omitted version must default to our latest, got: {result}"
+    );
+}
+
+/// MCP spells the tool capability `listChanged`; `{"list": true}` is not a
+/// thing in the schema.
+#[tokio::test]
+async fn initialize_advertises_tools_capability_in_the_spec_shape() {
+    let server = test_server("http://127.0.0.1:1");
+    let result = server
+        .dispatch("initialize", Some(json!({})))
+        .await
+        .expect("initialize should succeed");
+
+    let tools = result
+        .get("capabilities")
+        .and_then(|c| c.get("tools"))
+        .unwrap_or_else(|| panic!("capabilities.tools missing, got: {result}"));
+
+    assert!(
+        tools.get("listChanged").is_some(),
+        "capabilities.tools must use listChanged, got: {tools}"
+    );
+    assert!(
+        tools.get("list").is_none(),
+        "capabilities.tools.list is not in the MCP schema, got: {tools}"
     );
 }
 

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -17,7 +17,15 @@ use wiremock::matchers::{method as wm_method, path as wm_path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::server::DataGovMcpServer;
-use crate::types::{LATEST_PROTOCOL_VERSION, ServerError};
+use crate::types::{SUPPORTED_PROTOCOL_VERSIONS, ServerError};
+
+/// Revisions the MCP specification has actually published, oldest first.
+/// Literal on purpose: deriving it from `SUPPORTED_PROTOCOL_VERSIONS` would
+/// make these assertions agree with whatever that constant says.
+const PUBLISHED_MCP_REVISIONS: [&str; 4] = ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
+
+/// The revision marked *current* at modelcontextprotocol.io/specification/versioning.
+const CURRENT_MCP_REVISION: &str = "2025-11-25";
 
 /// Build a `DataGovMcpServer` whose internal client points at the given mock
 /// URL. Callers mount `Mock`s on the same server before exercising a dispatch
@@ -265,92 +273,175 @@ async fn dispatch_initialize_returns_raw_response() {
     );
 }
 
-/// The server must echo back a protocol version it supports when the client
-/// asks for one it knows.
+/// MCP 2025-11-25, Lifecycle / Version Negotiation: "If the server supports the
+/// requested protocol version, it MUST respond with the same version."
 #[tokio::test]
-async fn initialize_echoes_a_supported_protocol_version() {
+async fn initialize_echoes_every_published_revision_verbatim() {
     let server = test_server("http://127.0.0.1:1");
-    let result = server
-        .dispatch(
-            "initialize",
-            Some(json!({
-                "protocolVersion": "2025-06-18",
-                "capabilities": {},
-                "clientInfo": { "name": "test-client", "version": "0.0.0" }
-            })),
-        )
-        .await
-        .expect("initialize should succeed");
 
-    assert_eq!(
-        result.get("protocolVersion").and_then(|v| v.as_str()),
-        Some("2025-06-18"),
-        "a supported version must be echoed verbatim, got: {result}"
+    assert!(
+        SUPPORTED_PROTOCOL_VERSIONS.contains(&CURRENT_MCP_REVISION),
+        "server must speak the current MCP revision; advertises {SUPPORTED_PROTOCOL_VERSIONS:?}"
     );
+
+    for requested in PUBLISHED_MCP_REVISIONS {
+        let result = server
+            .dispatch(
+                "initialize",
+                Some(json!({
+                    "protocolVersion": requested,
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "0.0.0" }
+                })),
+            )
+            .await
+            .unwrap_or_else(|err| panic!("initialize({requested}) must succeed: {err}"));
+
+        assert_eq!(
+            result.get("protocolVersion").and_then(Value::as_str),
+            Some(requested),
+            "{requested} is a published revision this server advertises, so the spec \
+             requires echoing it verbatim; got: {result}"
+        );
+    }
+
+    for advertised in SUPPORTED_PROTOCOL_VERSIONS {
+        assert!(
+            PUBLISHED_MCP_REVISIONS.contains(advertised),
+            "{advertised} is not a published MCP revision"
+        );
+    }
 }
 
-/// When the client asks for a version we do not know, the spec says to reply
-/// with another version we support -- the latest -- not to error or echo.
+/// "Otherwise, the server MUST respond with another protocol version it
+/// supports. This SHOULD be the latest version supported by the server."
+/// The MUST is membership; the SHOULD is recency. Neither is asserted against
+/// `LATEST_PROTOCOL_VERSION`, which would compare the code with itself.
 #[tokio::test]
-async fn initialize_falls_back_to_latest_for_unknown_protocol_version() {
+async fn initialize_negotiates_unknown_or_absent_versions_to_the_current_revision() {
     let server = test_server("http://127.0.0.1:1");
-    let result = server
-        .dispatch(
-            "initialize",
-            Some(json!({
-                "protocolVersion": "1999-01-01",
-                "clientInfo": { "name": "test-client", "version": "0.0.0" }
-            })),
-        )
-        .await
-        .expect("initialize should succeed");
 
-    assert_eq!(
-        result.get("protocolVersion").and_then(|v| v.as_str()),
-        Some(LATEST_PROTOCOL_VERSION),
-        "an unknown version must fall back to our latest, got: {result}"
-    );
+    for requested in [
+        "1999-01-01",
+        "2025-06-19",
+        "2026-11-25",
+        "1.0.0",
+        "2025-11-25 ",
+        "",
+    ] {
+        let result = server
+            .dispatch("initialize", Some(json!({ "protocolVersion": requested })))
+            .await
+            .unwrap_or_else(|err| panic!("initialize({requested:?}) must not error: {err}"));
+
+        let answered = result
+            .get("protocolVersion")
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| panic!("protocolVersion must be a string, got: {result}"));
+
+        assert_ne!(
+            answered, requested,
+            "an unsupported version must never be echoed back"
+        );
+        assert!(
+            SUPPORTED_PROTOCOL_VERSIONS.contains(&answered),
+            "answered {answered:?}, which this server does not support"
+        );
+        assert_eq!(
+            answered, CURRENT_MCP_REVISION,
+            "fallback SHOULD be the latest we speak"
+        );
+    }
+
+    for params in [
+        None,
+        Some(json!({})),
+        Some(json!({ "protocolVersion": null })),
+    ] {
+        let shown = format!("{params:?}");
+        let result = server
+            .dispatch("initialize", params)
+            .await
+            .unwrap_or_else(|err| panic!("initialize({shown}) must not error: {err}"));
+        assert_eq!(
+            result.get("protocolVersion").and_then(Value::as_str),
+            Some(CURRENT_MCP_REVISION),
+            "omitted version must default to the current revision; params {shown} got: {result}"
+        );
+    }
 }
 
-/// A client that omits protocolVersion entirely still gets a usable answer.
+/// MCP 2025-11-25, server/tools: "Servers that support tools MUST declare the
+/// `tools` capability". `listChanged` is optional in the schema but typed
+/// boolean, and it is a behavioural promise: this server never emits
+/// `notifications/tools/list_changed`, so the honest value is false. Declaring
+/// a capability the dispatcher cannot serve breaks the lifecycle rule that both
+/// parties "only use capabilities that were successfully negotiated".
 #[tokio::test]
-async fn initialize_without_a_requested_version_returns_latest() {
+async fn initialize_declares_only_capabilities_the_server_can_serve() {
     let server = test_server("http://127.0.0.1:1");
     let result = server
         .dispatch("initialize", Some(json!({})))
         .await
         .expect("initialize should succeed");
 
-    assert_eq!(
-        result.get("protocolVersion").and_then(|v| v.as_str()),
-        Some(LATEST_PROTOCOL_VERSION),
-        "omitted version must default to our latest, got: {result}"
-    );
-}
-
-/// MCP spells the tool capability `listChanged`; `{"list": true}` is not a
-/// thing in the schema.
-#[tokio::test]
-async fn initialize_advertises_tools_capability_in_the_spec_shape() {
-    let server = test_server("http://127.0.0.1:1");
-    let result = server
-        .dispatch("initialize", Some(json!({})))
-        .await
-        .expect("initialize should succeed");
-
-    let tools = result
+    let caps = result
         .get("capabilities")
-        .and_then(|c| c.get("tools"))
-        .unwrap_or_else(|| panic!("capabilities.tools missing, got: {result}"));
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("capabilities is required and must be an object: {result}"));
 
-    assert!(
-        tools.get("listChanged").is_some(),
-        "capabilities.tools must use listChanged, got: {tools}"
+    let tools = caps
+        .get("tools")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("a tool server MUST declare capabilities.tools: {result}"));
+
+    assert_eq!(
+        tools.get("listChanged"),
+        Some(&json!(false)),
+        "listChanged is typed boolean, and this server never emits \
+         notifications/tools/list_changed, so it must be false; got: {tools:?}"
     );
+
+    // Whitelist, not a blacklist of the one historical bug: the next invented
+    // key ("listChange", "list_changed") must fail too.
+    let unknown: Vec<&str> = tools
+        .keys()
+        .map(String::as_str)
+        .filter(|key| *key != "listChanged")
+        .collect();
     assert!(
-        tools.get("list").is_none(),
-        "capabilities.tools.list is not in the MCP schema, got: {tools}"
+        unknown.is_empty(),
+        "not MCP tools-capability keys: {unknown:?}"
     );
+
+    for declared in caps.keys() {
+        assert!(
+            matches!(
+                declared.as_str(),
+                "tools" | "prompts" | "resources" | "logging" | "completions" | "experimental"
+            ),
+            "`{declared}` is not a server capability in the 2025-11-25 schema"
+        );
+    }
+
+    // Anything advertised must actually dispatch. A capability answered with
+    // -32601 is worse than an undeclared one: the client finds out mid-session.
+    for (capability, probe) in [
+        ("prompts", "prompts/list"),
+        ("resources", "resources/list"),
+        ("completions", "completion/complete"),
+        ("logging", "logging/setLevel"),
+    ] {
+        if caps.contains_key(capability) {
+            assert!(
+                !matches!(
+                    server.dispatch(probe, Some(json!({}))).await,
+                    Err(ServerError::InvalidMethod(_))
+                ),
+                "initialize declares `{capability}` but `{probe}` answers -32601"
+            );
+        }
+    }
 }
 
 #[tokio::test]

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -53,7 +53,8 @@ impl DataGovMcpServer {
         match method {
             "initialize" => {
                 let params: InitializeParams = parse_optional_params(method, params)?;
-                let result = InitializeResult::new(params.client_info);
+                let result =
+                    InitializeResult::new(params.protocol_version.as_deref(), params.client_info);
                 Ok(serde_json::to_value(result).map_err(ServerError::Serialization)?)
             }
             "initialized" => Ok(Value::Null),

--- a/data-gov-mcp-server/src/server.rs
+++ b/data-gov-mcp-server/src/server.rs
@@ -1,24 +1,10 @@
 //! MCP server entry point — struct definition, construction, and run loop.
 
 use data_gov::{DataGovClient, DataGovConfig, OperatingMode};
-use serde_json::json;
 use std::env;
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
 
 use crate::types::{Request, Response, ServerError};
-
-/// Supported JSON-RPC methods advertised in the ready message.
-const METHODS: &[&str] = &[
-    "initialize",
-    "initialized",
-    "shutdown",
-    "tools/list",
-    "data_gov.search",
-    "data_gov.dataset",
-    "data_gov.autocompleteDatasets",
-    "data_gov.listOrganizations",
-    "data_gov.downloadResources",
-];
 
 /// The data.gov MCP server.
 ///
@@ -64,7 +50,10 @@ impl DataGovMcpServer {
         let reader = BufReader::new(stdin);
         let mut writer = BufWriter::new(stdout);
 
-        self.send_ready(&mut writer).await?;
+        // Nothing is written to stdout until a request arrives. stdout is the
+        // protocol stream, and MCP expects the server to stay silent until it
+        // answers `initialize`; lifecycle chatter goes to stderr via tracing.
+        tracing::info!("data-gov MCP server ready");
 
         let mut lines = reader.lines();
 
@@ -94,26 +83,6 @@ impl DataGovMcpServer {
             }
         }
 
-        Ok(())
-    }
-
-    /// Emit the server-ready announcement.
-    async fn send_ready(&self, writer: &mut BufWriter<io::Stdout>) -> Result<(), ServerError> {
-        let ready = json!({
-            "jsonrpc": "2.0",
-            "id": null,
-            "result": {
-                "server": "data-gov-mcp-server",
-                "version": env!("CARGO_PKG_VERSION"),
-                "methods": METHODS,
-            }
-        });
-
-        let payload = serde_json::to_string(&ready).map_err(ServerError::Serialization)?;
-        writer.write_all(payload.as_bytes()).await?;
-        writer.write_all(b"\n").await?;
-        writer.flush().await?;
-        tracing::info!("data-gov MCP server ready");
         Ok(())
     }
 

--- a/data-gov-mcp-server/src/types.rs
+++ b/data-gov-mcp-server/src/types.rs
@@ -376,6 +376,18 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Revisions the MCP specification has actually published, oldest first.
+    ///
+    /// Deliberately literal. Deriving this from [`SUPPORTED_PROTOCOL_VERSIONS`]
+    /// would make every assertion below agree with whatever that constant happens
+    /// to say, so a revision quietly dropped — or invented — would stay green.
+    const PUBLISHED_MCP_REVISIONS: [&str; 4] =
+        ["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
+
+    /// The revision marked *current* at modelcontextprotocol.io/specification/versioning.
+    /// Bumping this is a deliberate act of adopting a new spec, not a side effect.
+    const CURRENT_MCP_REVISION: &str = "2025-11-25";
+
     #[test]
     fn parse_required_params_succeeds_with_valid_json() {
         let params = Some(json!({"slug": "my-dataset"}));
@@ -640,48 +652,145 @@ mod tests {
         assert_eq!(ci.version.as_deref(), Some("1.0"));
     }
 
+    /// MCP 2025-11-25, Version Negotiation: "If the server supports the
+    /// requested protocol version, it MUST respond with the same version."
+    ///
+    /// The revision list is literal on purpose. Iterating
+    /// `SUPPORTED_PROTOCOL_VERSIONS` would only prove `find(x in L) == x`,
+    /// which holds for any contents of `L` — including a list that has never
+    /// heard of the current revision.
     #[test]
-    fn negotiate_echoes_every_supported_version() {
-        for supported in SUPPORTED_PROTOCOL_VERSIONS {
+    fn negotiate_echoes_every_published_revision() {
+        for revision in PUBLISHED_MCP_REVISIONS {
+            assert!(
+                SUPPORTED_PROTOCOL_VERSIONS.contains(&revision),
+                "{revision} is a published MCP revision but is no longer advertised: \
+                 {SUPPORTED_PROTOCOL_VERSIONS:?}"
+            );
+            assert_eq!(negotiate_protocol_version(Some(revision)), revision);
+        }
+        for advertised in SUPPORTED_PROTOCOL_VERSIONS {
+            assert!(
+                PUBLISHED_MCP_REVISIONS.contains(advertised),
+                "{advertised} is not a published MCP revision"
+            );
+        }
+        assert_eq!(LATEST_PROTOCOL_VERSION, CURRENT_MCP_REVISION);
+    }
+
+    /// "Otherwise, the server MUST respond with another protocol version it
+    /// supports. This SHOULD be the latest version supported by the server."
+    /// The MUST is membership in the advertised set; the SHOULD is recency.
+    #[test]
+    fn negotiate_never_answers_with_an_unsupported_version() {
+        for requested in [
+            Some("1999-01-01"),
+            Some("2025-11-24"),  // one day off a real revision
+            Some("2025-11-25 "), // trailing whitespace is a different identifier
+            Some("1.0.0"),       // the spec's own error example
+            Some("latest"),
+            Some(""),
+            None,
+        ] {
+            let answered = negotiate_protocol_version(requested);
+            assert!(
+                SUPPORTED_PROTOCOL_VERSIONS.contains(&answered),
+                "negotiating {requested:?} answered {answered:?}, which this server cannot speak"
+            );
             assert_eq!(
-                negotiate_protocol_version(Some(supported)),
-                *supported,
-                "a version we advertise must be echoed verbatim"
+                answered, CURRENT_MCP_REVISION,
+                "fallback SHOULD be the current revision"
             );
         }
     }
 
-    #[test]
-    fn negotiate_falls_back_to_latest_for_unknown_or_absent() {
-        assert_eq!(
-            negotiate_protocol_version(Some("1999-01-01")),
-            LATEST_PROTOCOL_VERSION
-        );
-        assert_eq!(
-            negotiate_protocol_version(Some("")),
-            LATEST_PROTOCOL_VERSION
-        );
-        assert_eq!(negotiate_protocol_version(None), LATEST_PROTOCOL_VERSION);
-    }
-
+    /// The fallback clause is about which revision is *newest*, not which array
+    /// slot it occupies. `.last()` is positional: a newest-first list with
+    /// `LATEST` pointing at the oldest revision passes that while downgrading
+    /// every client. `YYYY-MM-DD` makes lexicographic max chronological, and
+    /// the shape check below is what licenses using `max()`.
     #[test]
     fn latest_protocol_version_is_the_newest_supported() {
+        let newest = SUPPORTED_PROTOCOL_VERSIONS
+            .iter()
+            .copied()
+            .max()
+            .expect("a server must support at least one revision");
+        assert_eq!(LATEST_PROTOCOL_VERSION, newest);
         assert_eq!(
-            SUPPORTED_PROTOCOL_VERSIONS.last().copied(),
-            Some(LATEST_PROTOCOL_VERSION),
-            "LATEST_PROTOCOL_VERSION must be the last entry in SUPPORTED_PROTOCOL_VERSIONS"
+            LATEST_PROTOCOL_VERSION, CURRENT_MCP_REVISION,
+            "server advertises {LATEST_PROTOCOL_VERSION} as its latest, but the current \
+             published MCP revision is {CURRENT_MCP_REVISION}"
         );
+
+        let mut sorted = SUPPORTED_PROTOCOL_VERSIONS.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(
+            sorted.as_slice(),
+            SUPPORTED_PROTOCOL_VERSIONS,
+            "SUPPORTED_PROTOCOL_VERSIONS must be sorted oldest-first with no duplicates"
+        );
+
+        for v in SUPPORTED_PROTOCOL_VERSIONS {
+            let b = v.as_bytes();
+            assert!(
+                b.len() == 10
+                    && b[4] == b'-'
+                    && b[7] == b'-'
+                    && b.iter().filter(|c| c.is_ascii_digit()).count() == 8,
+                "MCP revisions are YYYY-MM-DD date strings, got {v:?}"
+            );
+        }
     }
 
+    /// `InitializeResult` requires protocolVersion, capabilities and serverInfo;
+    /// serverInfo requires name and version. Probing every advertised revision
+    /// rather than one is what kills a constructor that never reads its
+    /// argument — with a single probe, a hardcoded constant is
+    /// indistinguishable from working negotiation.
     #[test]
     fn initialize_result_serializes_protocol_version_and_spec_capabilities() {
-        let v = serde_json::to_value(InitializeResult::new(Some("2025-06-18"), None))
-            .expect("serializes");
-        assert_eq!(v["protocolVersion"], "2025-06-18");
-        assert_eq!(v["capabilities"]["tools"]["listChanged"], false);
+        for requested in SUPPORTED_PROTOCOL_VERSIONS {
+            let v = serde_json::to_value(InitializeResult::new(Some(requested), None))
+                .expect("serializes");
+            assert_eq!(
+                v["protocolVersion"].as_str(),
+                Some(*requested),
+                "a supported version must be echoed verbatim, got: {v}"
+            );
+        }
+
+        for unsupported in ["1999-01-01", "", "latest", "2.0"] {
+            let v = serde_json::to_value(InitializeResult::new(Some(unsupported), None))
+                .expect("serializes");
+            let answered = v["protocolVersion"]
+                .as_str()
+                .expect("a string protocolVersion");
+            assert!(
+                SUPPORTED_PROTOCOL_VERSIONS.contains(&answered),
+                "answered {answered:?} for unsupported {unsupported:?}"
+            );
+            assert_eq!(answered, CURRENT_MCP_REVISION);
+        }
+
+        let v = serde_json::to_value(InitializeResult::new(None, None)).expect("serializes");
+        assert_eq!(v["protocolVersion"].as_str(), Some(CURRENT_MCP_REVISION));
+        assert_eq!(v["capabilities"]["tools"]["listChanged"], json!(false));
         assert!(
             v["capabilities"]["tools"].get("list").is_none(),
-            "`list` is not an MCP capability key"
+            "`list` is not a key of the tools capability"
+        );
+        assert!(
+            v.get("server_info").is_none(),
+            "result keys are camelCase, got: {v}"
+        );
+        assert_eq!(v["serverInfo"]["name"], "data-gov-mcp-server");
+        assert!(
+            v["serverInfo"]["version"]
+                .as_str()
+                .is_some_and(|s| !s.is_empty()),
+            "serverInfo.version must be a non-empty string, got: {v}"
         );
     }
 }

--- a/data-gov-mcp-server/src/types.rs
+++ b/data-gov-mcp-server/src/types.rs
@@ -229,9 +229,42 @@ pub(crate) struct AutocompleteParams {
     pub limit: Option<i32>,
 }
 
+/// MCP protocol versions this server can speak, oldest first.
+///
+/// Version identifiers are dates marking the last backwards-incompatible
+/// change, not a sequence — a client asking for one we do not list gets
+/// [`LATEST_PROTOCOL_VERSION`] instead.
+pub(crate) const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
+
+/// The newest protocol version this server supports.
+///
+/// Returned when the client requests a version we do not recognise, or omits
+/// the field entirely.
+pub(crate) const LATEST_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Resolve the protocol version for a session.
+///
+/// Per the MCP lifecycle spec: if the server supports the requested version it
+/// MUST reply with that same version; otherwise it MUST reply with another
+/// version it supports, which SHOULD be the latest.
+pub(crate) fn negotiate_protocol_version(requested: Option<&str>) -> &'static str {
+    requested
+        .and_then(|want| {
+            SUPPORTED_PROTOCOL_VERSIONS
+                .iter()
+                .find(|supported| **supported == want)
+                .copied()
+        })
+        .unwrap_or(LATEST_PROTOCOL_VERSION)
+}
+
 /// Parameters for `initialize`.
 #[derive(Debug, Default, Deserialize)]
 pub(crate) struct InitializeParams {
+    /// Protocol version the client wants to speak. Absent for older clients.
+    #[serde(default, rename = "protocolVersion")]
+    pub protocol_version: Option<String>,
     #[serde(default, rename = "clientInfo")]
     pub client_info: Option<ClientInfo>,
 }
@@ -247,6 +280,10 @@ pub(crate) struct ClientInfo {
 /// Result of the `initialize` handshake.
 #[derive(Debug, Serialize)]
 pub(crate) struct InitializeResult {
+    /// Negotiated protocol version. Required by the MCP schema — a client that
+    /// validates the result will abort the handshake without it.
+    #[serde(rename = "protocolVersion")]
+    pub protocol_version: &'static str,
     #[serde(rename = "serverInfo")]
     pub server_info: ServerInfo,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -256,21 +293,25 @@ pub(crate) struct InitializeResult {
 }
 
 impl InitializeResult {
-    /// Build an initialize result, echoing back client info if provided.
-    pub fn new(client_info: Option<ClientInfo>) -> Self {
+    /// Build an initialize result, negotiating the protocol version and
+    /// echoing back client info if provided.
+    pub fn new(requested_version: Option<&str>, client_info: Option<ClientInfo>) -> Self {
         let client_info = client_info.map(|info| ClientInfoSummary {
             name: info.name,
             version: info.version,
         });
 
         Self {
+            protocol_version: negotiate_protocol_version(requested_version),
             server_info: ServerInfo {
                 name: "data-gov-mcp-server",
                 version: env!("CARGO_PKG_VERSION"),
             },
+            // `listChanged` is the schema's name for this. Our tool list is
+            // static, so it is false: we never emit notifications/tools/list_changed.
             capabilities: Some(json!({
                 "tools": {
-                    "list": true
+                    "listChanged": false
                 }
             })),
             client_info,
@@ -581,7 +622,7 @@ mod tests {
 
     #[test]
     fn initialize_result_without_client_info() {
-        let result = InitializeResult::new(None);
+        let result = InitializeResult::new(None, None);
         assert_eq!(result.server_info.name, "data-gov-mcp-server");
         assert!(result.client_info.is_none());
         assert!(result.capabilities.is_some());
@@ -593,9 +634,54 @@ mod tests {
             name: "test-client".to_string(),
             version: Some("1.0".to_string()),
         };
-        let result = InitializeResult::new(Some(info));
+        let result = InitializeResult::new(None, Some(info));
         let ci = result.client_info.expect("should have client_info");
         assert_eq!(ci.name, "test-client");
         assert_eq!(ci.version.as_deref(), Some("1.0"));
+    }
+
+    #[test]
+    fn negotiate_echoes_every_supported_version() {
+        for supported in SUPPORTED_PROTOCOL_VERSIONS {
+            assert_eq!(
+                negotiate_protocol_version(Some(supported)),
+                *supported,
+                "a version we advertise must be echoed verbatim"
+            );
+        }
+    }
+
+    #[test]
+    fn negotiate_falls_back_to_latest_for_unknown_or_absent() {
+        assert_eq!(
+            negotiate_protocol_version(Some("1999-01-01")),
+            LATEST_PROTOCOL_VERSION
+        );
+        assert_eq!(
+            negotiate_protocol_version(Some("")),
+            LATEST_PROTOCOL_VERSION
+        );
+        assert_eq!(negotiate_protocol_version(None), LATEST_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn latest_protocol_version_is_the_newest_supported() {
+        assert_eq!(
+            SUPPORTED_PROTOCOL_VERSIONS.last().copied(),
+            Some(LATEST_PROTOCOL_VERSION),
+            "LATEST_PROTOCOL_VERSION must be the last entry in SUPPORTED_PROTOCOL_VERSIONS"
+        );
+    }
+
+    #[test]
+    fn initialize_result_serializes_protocol_version_and_spec_capabilities() {
+        let v = serde_json::to_value(InitializeResult::new(Some("2025-06-18"), None))
+            .expect("serializes");
+        assert_eq!(v["protocolVersion"], "2025-06-18");
+        assert_eq!(v["capabilities"]["tools"]["listChanged"], false);
+        assert!(
+            v["capabilities"]["tools"].get("list").is_none(),
+            "`list` is not an MCP capability key"
+        );
     }
 }


### PR DESCRIPTION
Targets `release/0.5.0`. Closes #44, closes #29.

## What was broken

`initialize` omitted `protocolVersion`, which the MCP schema requires. Any client that validates the result aborted the handshake, so **no tool was ever reachable** — the server was unusable from a spec-compliant client despite the README documenting VS Code and Claude Desktop setup.

## The fix

**Negotiate, don't hardcode.** Per the [lifecycle spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle): reply with the client's requested version if supported, otherwise our latest. Supported: `2024-11-05`, `2025-03-26`, `2025-06-18`, `2025-11-25`.

Worth noting `2025-11-25` is the **current** revision — I checked the spec rather than assuming, and would otherwise have written `2025-06-18`.

**`capabilities.tools.listChanged`, not `list`.** `list` is not a key in the schema. Ours is `false` because the tool list is static.

**`send_ready` removed.** It wrote `{"jsonrpc":"2.0","id":null,"result":{...}}` before any client input — matching no MCP message, and not valid JSON-RPC either, since a `result` response with a null id corresponds to no request. stdout is the protocol stream; the announcement moves to stderr via `tracing`, where the lifecycle log already was. `METHODS` existed only to populate that line and goes with it.

## The test that could not fail

```rust
result.get("serverInfo").is_some() || result.get("protocolVersion").is_some()
```

`serverInfo` is always present, so `||` short-circuits and the missing field was never checked. Split into two assertions, plus new coverage for echo, fallback, omitted-version, and capability shape. Once fixed, it failed correctly before the implementation landed.

## Verification

TDD throughout — tests written first, confirmed red on assertions (not compilation), then green.

End to end against the built binary:

```
handshake            1 stdout line (was 2); protocolVersion=2025-11-25;
                     capabilities={"tools":{"listChanged":false}}
empty stdin          0 bytes on stdout
notifications        correctly unanswered
requested 2024-11-05 -> 2024-11-05     (echoed)
requested 2025-06-18 -> 2025-06-18     (echoed)
requested 1999-01-01 -> 2025-11-25     (fallback)
```

Gate green: fmt, clippy `-D warnings`, **189 tests**, docs.

## Reference

Cross-checked against the `adelie-ai/mcp-core` implementation, which independently arrives at the same negotiate-or-fallback design and the same `listChanged` shape. Not usable as a dependency here — that crate is git-only and unpublished, and `cargo publish` rejects git dependencies, so a crates.io workspace can't consume it. (The `mcp-core` on crates.io is an unrelated crate by a different author.)

## Still open on this server

This gets a client **connected**. It will then break on the first `tools/call`, because every tool result carries a `{"type":"json"}` content block that is not a valid MCP content type — **#60**. That is the natural next PR, and `mcp-core` corroborates the fix there too (`content` text blocks plus a sibling `structuredContent`).

Also still open: #65 serial dispatch, #55 protocol edges, #70 handler contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNz3zUgD2n8ckZkCTfdx8