### PR TITLE
fix(mcp): move structured payloads out of content into structuredContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **`structuredContent` is now always a JSON object** (#60). Two tools —
+  `data_gov.listOrganizations` and `data_gov.autocompleteDatasets` — returned a
+  bare JSON array, which the spec does not permit: structured content "is
+  returned as a JSON object". They now return `{"organizations": [...]}` and
+  `{"datasets": [...]}` respectively. If you were reading the array directly,
+  read the named key instead.
+
 - **Tool results no longer contain a `{"type":"json"}` content block** (#60).
   MCP's `content` is a closed union of `text`, `image`, `audio`,
   `resource_link` and `resource`; `json` is not a member, so every tool result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking
 
+- **Tool results no longer contain a `{"type":"json"}` content block** (#60).
+  MCP's `content` is a closed union of `text`, `image`, `audio`,
+  `resource_link` and `resource`; `json` is not a member, so every tool result
+  this server produced failed schema validation on a strict client. The
+  machine-readable payload moves to the sibling `structuredContent` field, and
+  the pretty-printed text block stays, as the spec recommends for clients that
+  do not read structured output. If you were reading
+  `content[1].json`, read `structuredContent` instead.
+
 - **MCP `initialize` now returns the required `protocolVersion`** and negotiates
   it (#44). The server advertises `2024-11-05`, `2025-03-26`, `2025-06-18`, and
   `2025-11-25`: a version it supports is echoed verbatim, anything else (or an

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -41,13 +41,24 @@ fn tool_response_json(value: &Value) -> &Value {
         .get("content")
         .and_then(Value::as_array)
         .expect("ToolResponse must have content array");
-    let json_item = content
-        .iter()
-        .find(|item| item.get("type").and_then(Value::as_str) == Some("json"))
-        .expect("ToolResponse must contain a json item");
-    json_item
-        .get("json")
-        .expect("json item must have inner 'json' field")
+    // `content` is a closed union in MCP; a structured payload rides alongside
+    // it in `structuredContent`, never as a content block.
+    for block in content {
+        let ty = block
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            matches!(
+                ty,
+                "text" | "image" | "audio" | "resource_link" | "resource"
+            ),
+            "`{ty}` is not an MCP content type"
+        );
+    }
+    value
+        .get("structuredContent")
+        .expect("tool result must carry structuredContent")
 }
 
 /// Minimal search response body matching the Catalog API shape.

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -531,3 +531,99 @@ async fn dispatch_download_resources_rejects_parent_traversal_in_output_dir() {
         other => panic!("expected InvalidParams, got {other:?}"),
     }
 }
+
+/// MCP 2025-11-25, server/tools: structured content "is returned as a JSON
+/// object in the `structuredContent` field", and `content` is a closed union.
+///
+/// Driven off `TOOL_SPECS` rather than a hand-picked tool. Exercising one tool
+/// is what let two of five ship a bare JSON array in `structuredContent`:
+/// `data_gov.listOrganizations` and `data_gov.autocompleteDatasets` both return
+/// `Vec<String>`, and a single-tool check on `data_gov_search` — which happens
+/// to return an object — reported the shape as conformant.
+///
+/// A new tool added without a fixture here fails rather than being skipped.
+#[tokio::test]
+async fn every_tool_returns_object_shaped_structured_content() {
+    fn arguments_for(tool: &str) -> Value {
+        match tool {
+            "data_gov_search" => json!({"query": "climate", "limit": 1}),
+            "data_gov_dataset" => json!({"slug": "probe-dataset"}),
+            "data_gov_autocomplete_datasets" => json!({"partial": "clim", "limit": 2}),
+            "data_gov_list_organizations" => json!({"limit": 2}),
+            "data_gov_download_resources" => json!({"datasetId": "probe-dataset"}),
+            other => panic!("no fixture arguments for `{other}`; add them with the tool"),
+        }
+    }
+
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/search"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(search_body("probe-dataset", "Probe Dataset")),
+        )
+        .mount(&mock)
+        .await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/api/organizations"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "organizations": [
+                {"id": "1", "name": "NASA", "slug": "nasa"},
+                {"id": "2", "name": "NOAA", "slug": "noaa"}
+            ],
+            "total": 2
+        })))
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    for spec in crate::tools::TOOL_SPECS.iter() {
+        let args = arguments_for(spec.tool_name);
+        let outcome = server
+            .dispatch(
+                "tools/call",
+                Some(json!({ "name": spec.tool_name, "arguments": args })),
+            )
+            .await;
+
+        // A tool may legitimately fail against this mock (the download tool
+        // reaches for distributions the fixture has none of). What must never
+        // happen is a *successful* result in a non-conformant shape.
+        let Ok(value) = outcome else { continue };
+
+        for block in value["content"].as_array().expect("content array") {
+            let ty = block["type"].as_str().expect("every block has a type");
+            assert!(
+                matches!(
+                    ty,
+                    "text" | "image" | "audio" | "resource_link" | "resource"
+                ),
+                "{}: `{ty}` is not an MCP content type",
+                spec.tool_name
+            );
+        }
+
+        // Presence is required, not merely checked-if-present. `from_value`
+        // drops a non-object defensively, so `if let Some(..)` here would pass
+        // for a handler that emitted a bare array: the guard would hide exactly
+        // the bug this test exists to catch.
+        let sc = value.get("structuredContent").unwrap_or_else(|| {
+            panic!(
+                "{}: every tool returns machine-readable data, so structuredContent must be \
+                 present. Absent means the handler passed a non-object and the guard in \
+                 ToolResponse::from_value dropped it: {value}",
+                spec.tool_name
+            )
+        });
+        assert!(
+            sc.is_object(),
+            "{}: structuredContent must be a JSON object, got {}: {sc}",
+            spec.tool_name,
+            if sc.is_array() {
+                "an array"
+            } else {
+                "a scalar"
+            }
+        );
+    }
+}

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -81,13 +81,16 @@ impl DataGovMcpServer {
                     .data_gov
                     .autocomplete_datasets(&params.partial, params.limit)
                     .await?;
-                Ok(serde_json::to_value(result).map_err(ServerError::Serialization)?)
+                // A named object, not the bare Vec. MCP defines structuredContent
+                // as a JSON object, and a key leaves room to add fields later
+                // without breaking consumers.
+                Ok(json!({ "datasets": result }))
             }
             "data_gov.listOrganizations" => {
                 let params: ListOrganizationsParams = parse_optional_params(method, params)?;
                 validate_limit(method, params.limit, 1, 1000)?;
                 let result = self.data_gov.list_organizations(params.limit).await?;
-                Ok(serde_json::to_value(result).map_err(ServerError::Serialization)?)
+                Ok(json!({ "organizations": result }))
             }
             "data_gov.downloadResources" => self.handle_download_resources(method, params).await,
             other => Err(ServerError::InvalidMethod(other.to_string())),

--- a/data-gov-mcp-server/src/tools.rs
+++ b/data-gov-mcp-server/src/tools.rs
@@ -50,11 +50,19 @@ impl ToolResponse {
     /// The spec puts machine-readable output in `structuredContent`, and says a
     /// tool that does so SHOULD also return the serialized JSON as a text block
     /// for clients that do not read the structured field — hence both.
+    /// `structuredContent` is populated only for JSON **objects**, because that
+    /// is what the spec defines it as: structured content "is returned as a
+    /// JSON object in the `structuredContent` field". A bare array or scalar is
+    /// omitted from the structured field rather than emitted in a shape no
+    /// client is obliged to accept; the text block still carries it. Handlers
+    /// should pass a named object so this never triggers, and
+    /// `every_tool_returns_object_shaped_structured_content` holds them to it.
     pub fn from_value(value: Value) -> Self {
         let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+        let structured_content = value.is_object().then_some(value);
         Self {
             content: vec![ToolContent::Text { text }],
-            structured_content: Some(value),
+            structured_content,
             is_error: None,
         }
     }
@@ -298,47 +306,95 @@ mod tests {
         assert!(find_tool_spec_by_method("nonexistent.method").is_none());
     }
 
-    /// The spec says a tool returning structured content SHOULD also return the
-    /// serialized JSON in a text block, so both are expected -- but the
-    /// structured half belongs in `structuredContent`, not in `content`.
+    /// MCP 2025-11-25, server/tools: structured content "is returned as a JSON
+    /// object in the structuredContent field", and a tool returning it SHOULD
+    /// "also return the serialized JSON in a TextContent block". Both halves
+    /// must be present and must agree.
+    ///
+    /// The value has several keys on purpose: with one key, an implementation
+    /// that serialized only the first field would be byte-identical to a
+    /// correct one.
     #[test]
-    fn tool_response_from_value_has_one_text_block_and_structured_content() {
-        let val = json!({"count": 5});
+    fn tool_response_text_block_round_trips_to_the_structured_content() {
+        let val = json!({"count": 5, "name": "second", "nested": {"a": [1, 2]}});
         let resp = ToolResponse::from_value(val.clone());
 
-        assert_eq!(
-            resp.content.len(),
-            1,
-            "content must hold only the text block"
-        );
-        let ToolContent::Text { text } = &resp.content[0];
-        assert!(text.contains("\"count\": 5"));
-        assert_eq!(
-            resp.structured_content.as_ref(),
-            Some(&val),
-            "the raw value belongs in structuredContent"
-        );
+        assert_eq!(resp.content.len(), 1, "content holds only the text block");
+        assert_eq!(resp.structured_content.as_ref(), Some(&val));
         assert!(resp.is_error.is_none());
+
+        // Reparse rather than substring-match: a substring check passes for a
+        // truncated or reordered serialization, and would also fail spuriously
+        // if pretty-printing were swapped for compact output, which the spec
+        // does not care about.
+        let v = serde_json::to_value(&resp).expect("serializes");
+        let text = v["content"][0]["text"].as_str().expect("text block");
+        let reparsed: Value = serde_json::from_str(text).expect("text block is valid JSON");
+        assert_eq!(reparsed, val, "the text block must carry the whole value");
     }
 
     /// `content` is a closed union of text, image, audio, resource_link and
-    /// resource. A `{"type":"json"}` block is not a member, and every result
-    /// carrying one fails schema validation on a strict client.
+    /// resource. Conformance needs two things: the `type` must name a member,
+    /// and the block must carry that member's required fields. A block tagged
+    /// `resource` that actually holds `text` is as non-conformant as one tagged
+    /// `json`, and checking only the discriminator misses it — renaming the
+    /// serde tag is a one-word mutation.
     #[test]
     fn tool_response_serializes_only_spec_valid_content_types() {
-        const VALID: [&str; 5] = ["text", "image", "audio", "resource_link", "resource"];
-
         let v = serde_json::to_value(ToolResponse::from_value(json!({"count": 5})))
             .expect("serializes");
 
         let content = v["content"].as_array().expect("content is an array");
+        assert!(
+            !content.is_empty(),
+            "an empty array satisfies a per-block loop vacuously"
+        );
+
         for block in content {
             let ty = block["type"].as_str().expect("every block has a type");
+            let required: &[&str] = match ty {
+                "text" => &["text"],
+                "image" | "audio" => &["data", "mimeType"],
+                "resource_link" => &["uri", "name"],
+                "resource" => &["resource"],
+                other => panic!(
+                    "`{other}` is not an MCP content type; valid: text, image, audio, \
+                     resource_link, resource"
+                ),
+            };
+            for field in required {
+                assert!(
+                    block.get(*field).is_some(),
+                    "`{ty}` block missing required field `{field}`: {block}"
+                );
+            }
+        }
+
+        assert_eq!(v["structuredContent"], json!({"count": 5}));
+    }
+
+    /// A bare array is not a JSON object, so it must never reach
+    /// structuredContent. Regression guard for two tools that passed
+    /// `Vec<String>` straight through.
+    #[test]
+    fn non_object_payloads_stay_out_of_structured_content() {
+        for payload in [json!(["a", "b"]), json!("scalar"), json!(7), json!(null)] {
+            let resp = ToolResponse::from_value(payload.clone());
             assert!(
-                VALID.contains(&ty),
-                "`{ty}` is not an MCP content type; valid: {VALID:?}"
+                resp.structured_content.is_none(),
+                "{payload} is not an object and must not be structuredContent"
+            );
+            let v = serde_json::to_value(&resp).expect("serializes");
+            assert!(
+                v.get("structuredContent").is_none(),
+                "structuredContent must be omitted entirely, not null"
+            );
+            // The data still has to reach the client somehow.
+            let text = v["content"][0]["text"].as_str().expect("text block");
+            assert_eq!(
+                serde_json::from_str::<Value>(text).expect("valid JSON"),
+                payload
             );
         }
-        assert_eq!(v["structuredContent"], json!({"count": 5}));
     }
 }

--- a/data-gov-mcp-server/src/tools.rs
+++ b/data-gov-mcp-server/src/tools.rs
@@ -33,32 +33,41 @@ pub(crate) struct ToolDescriptor {
 /// Wrapper for tool invocation results.
 #[derive(Debug, Serialize)]
 pub(crate) struct ToolResponse {
+    /// Unstructured content blocks. MCP defines this as a closed union, so
+    /// only the variants of [`ToolContent`] may appear here.
     pub content: Vec<ToolContent>,
+    /// Machine-readable result, carried beside `content` rather than inside it.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "structuredContent")]
+    pub structured_content: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "isError")]
     pub is_error: Option<bool>,
 }
 
 impl ToolResponse {
-    /// Build a response containing both pretty-printed text and raw JSON.
+    /// Build a response carrying the value as both a text block and structured
+    /// content.
+    ///
+    /// The spec puts machine-readable output in `structuredContent`, and says a
+    /// tool that does so SHOULD also return the serialized JSON as a text block
+    /// for clients that do not read the structured field — hence both.
     pub fn from_value(value: Value) -> Self {
         let text = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
         Self {
-            content: vec![
-                ToolContent::Text { text },
-                ToolContent::Json { json: value },
-            ],
+            content: vec![ToolContent::Text { text }],
+            structured_content: Some(value),
             is_error: None,
         }
     }
 }
 
 /// Individual content item within a [`ToolResponse`].
+///
+/// MCP's `content` is a closed union of `text`, `image`, `audio`,
+/// `resource_link` and `resource`. Only `text` is produced today; adding a
+/// variant here means adding one the spec actually defines.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type")]
 pub(crate) enum ToolContent {
-    /// Raw JSON payload.
-    #[serde(rename = "json")]
-    Json { json: Value },
     /// Human-readable text representation.
     #[serde(rename = "text")]
     Text { text: String },
@@ -289,24 +298,47 @@ mod tests {
         assert!(find_tool_spec_by_method("nonexistent.method").is_none());
     }
 
+    /// The spec says a tool returning structured content SHOULD also return the
+    /// serialized JSON in a text block, so both are expected -- but the
+    /// structured half belongs in `structuredContent`, not in `content`.
     #[test]
-    fn tool_response_from_value_has_text_and_json() {
+    fn tool_response_from_value_has_one_text_block_and_structured_content() {
         let val = json!({"count": 5});
         let resp = ToolResponse::from_value(val.clone());
-        assert_eq!(resp.content.len(), 2);
-        assert!(resp.is_error.is_none());
 
-        match &resp.content[0] {
-            ToolContent::Text { text } => {
-                assert!(text.contains("\"count\": 5"));
-            }
-            other => panic!("expected Text, got: {:?}", other),
+        assert_eq!(
+            resp.content.len(),
+            1,
+            "content must hold only the text block"
+        );
+        let ToolContent::Text { text } = &resp.content[0];
+        assert!(text.contains("\"count\": 5"));
+        assert_eq!(
+            resp.structured_content.as_ref(),
+            Some(&val),
+            "the raw value belongs in structuredContent"
+        );
+        assert!(resp.is_error.is_none());
+    }
+
+    /// `content` is a closed union of text, image, audio, resource_link and
+    /// resource. A `{"type":"json"}` block is not a member, and every result
+    /// carrying one fails schema validation on a strict client.
+    #[test]
+    fn tool_response_serializes_only_spec_valid_content_types() {
+        const VALID: [&str; 5] = ["text", "image", "audio", "resource_link", "resource"];
+
+        let v = serde_json::to_value(ToolResponse::from_value(json!({"count": 5})))
+            .expect("serializes");
+
+        let content = v["content"].as_array().expect("content is an array");
+        for block in content {
+            let ty = block["type"].as_str().expect("every block has a type");
+            assert!(
+                VALID.contains(&ty),
+                "`{ty}` is not an MCP content type; valid: {VALID:?}"
+            );
         }
-        match &resp.content[1] {
-            ToolContent::Json { json } => {
-                assert_eq!(*json, val);
-            }
-            other => panic!("expected Json, got: {:?}", other),
-        }
+        assert_eq!(v["structuredContent"], json!({"count": 5}));
     }
 }


### PR DESCRIPTION
**Stacked on #90** — targets `fix/mcp-initialize`, not the release branch, since it builds directly on it. Merge #90 first and this retargets cleanly. Closes #60.

## What was broken

Every tool result carried two content blocks — a text block and a `{"type":"json"}` block. MCP's `CallToolResult.content` is a **closed union**: `text`, `image`, `audio`, `resource_link`, `resource`. `json` is not a member, so **100% of this server's tool results failed schema validation** on a strict client.

Together with #90 this is why the server was unusable end to end: #90 gets a client through the handshake, and it would then have broken on the very first `tools/call`.

## The fix

Machine-readable output moves to the sibling `structuredContent` field.

**The text block stays.** The spec is explicit — "a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block" — for clients that do not read the structured field. So emitting both is correct, not redundant.

**No `outputSchema` declared.** The spec makes it optional ("Tools *may* also provide an output schema") and requires conformance only *if* one is present. Declaring schemas for the five tools is worth doing later; it is not required for results to be valid, and adding them now would be a larger change with its own correctness risk.

`ToolContent` loses its `Json` variant, leaving a single `Text` arm — which made the catch-all in its test unreachable and tripped `-D warnings`. Destructured directly rather than suppressing the lint.

## The two tests that locked the defect in

Both asserted the non-conformant shape, exactly as #60 predicted:

- `tools.rs` — asserted `content.len() == 2` with `content[1]` being `Json`
- the `dispatch_tests` helper — dug the payload out of a content item with `type == "json"`

Both now assert the spec shape. The helper additionally **rejects any content block whose type falls outside the union**, so a future regression fails loudly instead of passing quietly.

## Verification

TDD: tests rewritten to the spec shape first, confirmed failing to compile against the old struct, then implemented.

End to end against the built binary, full lifecycle:

```
initialize   protocolVersion=2025-11-25
tools/list   5 tools
tools/call   content types=['text']  invalid=none
             structuredContent present=True
```

Gate green: fmt, clippy `-D warnings`, **190 tests**, docs.

## Remaining on this server

#65 serial dispatch, #55 protocol edges, #70 handler contract. With #90 and this merged, a spec-compliant client can complete a handshake, list tools, and call one with a conformant result — the server is usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNz3zUgD2n8ckZkCTfdx8