### PR TITLE
fix(catalog): resolve datasets by slug through the exact-lookup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - Unreleased
 
 ### Breaking
-
 - **`structuredContent` is now always a JSON object** (#60). Two tools —
   `data_gov.listOrganizations` and `data_gov.autocompleteDatasets` — returned a
   bare JSON array, which the spec does not permit: structured content "is
@@ -46,13 +45,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   goes to stderr via `tracing` at startup.
 
 ### Changed
-
 - All dependencies refreshed to their latest semver-compatible releases.
   `rustyline` 17 → 18 is deliberately **not** included; it is a major bump
   under the whole REPL and is tracked separately.
 
 ### Security
-
 - **Cleared three advisories** by refreshing the lockfile (#46):
   - `quinn-proto` 0.11.14 → 0.11.16 — RUSTSEC-2026-0185, remote memory
     exhaustion from unbounded out-of-order stream reassembly (7.5 High).
@@ -64,15 +61,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `anyhow` 1.0.102 → 1.0.104 — RUSTSEC-2026-0190, unsoundness in
     `Error::downcast_mut()`.
 
-### Removed
+### Fixed
+- **`dataset_by_slug` now resolves every dataset that exists** (#94). It was
+  implemented as a full-text search — `q=<slug>&per_page=20`, scanning the page
+  for an exact match — because the `slug=` query parameter it was written
+  against never existed in the API. A slug is a lossy derivation of the title
+  (truncated at 90 characters mid-word, punctuation collapsed, `U.S.` flattened
+  to `u-s`), so its tokens are frequently absent from the indexed text and the
+  query returned nothing. Measured against live data.gov: **15% of datasets
+  unresolvable on a uniform sample, 27% past cursor depth 400, ~69% of slugs at
+  the 90-character cap.**
 
+  It now uses `GET /api/dataset/{slug_or_id}`, the exact-lookup endpoint
+  declared in the API's own OpenAPI document at `/openapi.json`. Same one
+  request, no ranking, no prefix matching. This affects every entry point that
+  takes a slug — REPL `cd`/`show`/`download`, one-shot CLI, and the
+  `data_gov.dataset` and `data_gov.downloadResources` MCP tools — all of which
+  previously reported "not found" for datasets they had just listed.
+- **A data.gov outage is no longer reported as a missing dataset** (#94). Only a
+  404 yields `Ok(None)`; every other non-2xx surfaces as
+  `CatalogError::ApiError` and network failure as `CatalogError::RequestError`.
+- **The slug is percent-encoded into a single path segment**, so a value
+  containing `..`, `%2e` or a slash cannot redirect the request to another
+  endpoint.
+
+### Removed
 - Six declared-but-unused dependencies (#76): `serde`, `serde_json`,
   `tokio-util`, and `anyhow` from `data-gov`; `futures` and `data-gov-catalog`
   from `data-gov-mcp-server`, which reaches catalog types through the
   `data_gov::catalog` re-export. The lockfile drops from 308 to 279 crates.
 
 ### Infrastructure
-
 - Documented the testing standard in `CLAUDE.md`: test conditions derive from
   the specification or real API data and never from the current implementation;
   every test must name the wrong implementation it would catch; real captured

--- a/data-gov-catalog/README.md
+++ b/data-gov-catalog/README.md
@@ -128,7 +128,7 @@ if let Some(hit) = hit {
 | Method                        | Endpoint                              | Returns                       |
 |-------------------------------|---------------------------------------|-------------------------------|
 | `search(params)`              | `GET /search`                         | `SearchResponse`              |
-| `dataset_by_slug(slug)`       | `GET /search?slug=…&per_page=1`       | `Option<SearchHit>`           |
+| `dataset_by_slug(slug)`       | `GET /api/dataset/{slug}`             | `Option<SearchHit>`           |
 | `organizations()`             | `GET /api/organizations`              | `OrganizationsResponse`       |
 | `keywords(size, min_count)`   | `GET /api/keywords`                   | `KeywordsResponse`            |
 | `locations_search(q, size)`   | `GET /api/locations/search`           | `LocationsResponse`           |

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -37,6 +37,23 @@ impl Default for Configuration {
     }
 }
 
+/// Percent-encode a single URL path segment.
+///
+/// Everything outside the unreserved set is escaped, including `/` and `.`, so
+/// a value containing `..`, `%2e` or a slash cannot escape its segment and
+/// redirect the request to a different endpoint. `.` is escaped rather than
+/// passed through precisely so that `..` cannot survive as a dot-segment.
+fn encode_path_segment(segment: &str) -> String {
+    let mut out = String::with_capacity(segment.len());
+    for byte in segment.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'~' => out.push(byte as char),
+            other => out.push_str(&format!("%{other:02X}")),
+        }
+    }
+    out
+}
+
 /// Async client for the Catalog API.
 ///
 /// Holds an [`Arc<Configuration>`] so it's cheap to clone and share across
@@ -248,6 +265,45 @@ impl CatalogClient {
         format!("{base}{path}")
     }
 
+    /// Issue a GET where a 404 means "no such thing" rather than a failure.
+    ///
+    /// Distinct from [`Self::get_json`], which treats every non-2xx as an
+    /// error. Collapsing the two is how a data.gov outage came to be reported
+    /// to users as a missing dataset.
+    async fn get_json_optional<T: DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<Option<T>, CatalogError> {
+        let mut req = self.configuration.client.get(self.url(path));
+        if let Some(ua) = &self.configuration.user_agent {
+            req = req.header(reqwest::header::USER_AGENT, ua);
+        }
+        let response = req
+            .send()
+            .await
+            .map_err(|e| CatalogError::RequestError(Box::new(e)))?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let message = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<no body>".to_string());
+            return Err(CatalogError::ApiError { status, message });
+        }
+
+        let bytes = response
+            .bytes()
+            .await
+            .map_err(|e| CatalogError::RequestError(Box::new(e)))?;
+        serde_json::from_slice(&bytes)
+            .map(Some)
+            .map_err(CatalogError::ParseError)
+    }
+
     /// Issue a GET with optional query parameters and deserialize the JSON body.
     async fn get_json<T: DeserializeOwned, Q: serde::Serialize + ?Sized>(
         &self,
@@ -301,24 +357,32 @@ impl CatalogClient {
     /// [`SearchHit`](models::SearchHit) carries the denormalized fields and a
     /// nested `dcat` record with the full DCAT-US 3 metadata.
     ///
-    /// # Notes
+    /// Uses `GET /api/dataset/{slug_or_id}`, the exact-lookup endpoint declared
+    /// in the API's own OpenAPI document at `/openapi.json`. Lookup is exact:
+    /// the endpoint does no prefix or substring matching, so a near-miss slug
+    /// returns 404 rather than a plausible wrong dataset.
     ///
-    /// The Catalog API does not actually honor a `slug=` query parameter
-    /// today — it returns the top relevance hit regardless of the value.
-    /// We work around this by using a full-text query (`q=<slug>`) and then
-    /// scanning the first page for a hit whose `slug` exactly matches.
-    /// Slug-shaped queries reliably rank the exact match first when it
-    /// exists; we look at the top 20 results to leave headroom for ties.
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::ApiError`] for any non-2xx status other than
+    /// 404, [`CatalogError::RequestError`] for network or TLS failure, and
+    /// [`CatalogError::ParseError`] if the body is not a valid
+    /// [`SearchResponse`](models::SearchResponse). A 404 is *not* an error — it
+    /// is the "no such dataset" answer and yields `Ok(None)`.
     pub async fn dataset_by_slug(
         &self,
         slug: &str,
     ) -> Result<Option<models::SearchHit>, CatalogError> {
-        let params = SearchParams::new().q(slug).per_page(20);
-        let response: models::SearchResponse = self.search(params).await?;
+        let path = format!("/api/dataset/{}", encode_path_segment(slug));
+        let response: Option<models::SearchResponse> = self.get_json_optional(&path).await?;
+
+        // Belt and braces: the endpoint is exact, but a hit whose slug differs
+        // from the request would mean the server matched something else, and
+        // returning it would be the silent-wrong-dataset failure this call
+        // exists to avoid.
         Ok(response
-            .results
-            .into_iter()
-            .find(|hit| hit.slug.as_deref() == Some(slug)))
+            .and_then(|r| r.results.into_iter().next())
+            .filter(|hit| hit.slug.as_deref() == Some(slug)))
     }
 
     /// List all organizations known to the catalog.

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -92,105 +92,126 @@ async fn search_with_org_slug_passes_filter() {
 }
 
 #[tokio::test]
-async fn dataset_by_slug_returns_first_hit() {
+async fn dataset_by_slug_returns_the_dataset() {
+    let slug = "crime-data-from-2020-to-present";
     let server = MockServer::start().await;
-    // dataset_by_slug uses q=<slug> (the API doesn't honor slug= today)
-    // and matches the slug client-side.
     Mock::given(method("GET"))
-        .and(path("/search"))
-        .and(query_param("q", "crime-data-from-2020-to-present"))
+        .and(path(format!("/api/dataset/{slug}")))
         .respond_with(
             ResponseTemplate::new(200)
-                .set_body_raw(fixture("search_by_slug.json"), "application/json"),
+                .set_body_raw(fixture("dataset_by_slug.json"), "application/json"),
         )
         .mount(&server)
         .await;
 
-    let client = client_for(&server);
-    let hit = client
-        .dataset_by_slug("crime-data-from-2020-to-present")
+    let hit = client_for(&server)
+        .dataset_by_slug(slug)
         .await
         .expect("slug lookup succeeds")
         .expect("slug matches a dataset");
 
+    assert_eq!(hit.slug.as_deref(), Some(slug));
     assert!(hit.title.is_some());
-    assert!(hit.dcat.is_some());
+    assert!(hit.dcat.is_some(), "the full DCAT record must come through");
 }
 
+/// The endpoint is exact, but if it ever answered with a different dataset we
+/// must not hand it back: returning a plausible wrong dataset is worse than
+/// returning nothing, because the caller cannot tell.
 #[tokio::test]
-async fn dataset_by_slug_returns_none_when_empty() {
+async fn dataset_by_slug_returns_none_when_the_hit_has_a_different_slug() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/search"))
+        .and(path("/api/dataset/nasa-thesaurus"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "results": [],
-            "sort": "relevance"
-        })))
-        .mount(&server)
-        .await;
-
-    let client = client_for(&server);
-    let result = client.dataset_by_slug("nonexistent").await.unwrap();
-    assert!(result.is_none());
-}
-
-/// The live Catalog API doesn't honor a `slug=` query parameter — it
-/// returns the top relevance hit regardless. We work around it with
-/// `q=<slug>` plus a client-side slug-equality check. Make sure that
-/// check actually fires when the API returns a non-matching hit.
-#[tokio::test]
-async fn dataset_by_slug_returns_none_when_top_hit_has_a_different_slug() {
-    let server = MockServer::start().await;
-    Mock::given(method("GET"))
-        .and(path("/search"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "total": 1,
             "results": [{
                 "slug": "crime-data-from-2020-to-present",
-                "title": "Crime Data from 2020 to 2024"
-            }],
-            "sort": "relevance"
+                "title": "A completely different dataset"
+            }]
         })))
         .mount(&server)
         .await;
 
-    let client = client_for(&server);
-    let result = client.dataset_by_slug("nasa-thesaurus").await.unwrap();
+    let result = client_for(&server)
+        .dataset_by_slug("nasa-thesaurus")
+        .await
+        .expect("lookup succeeds");
     assert!(
         result.is_none(),
-        "expected None when API returns a hit with a different slug, got Some(_)"
+        "a hit whose slug differs from the request must not be returned, got {result:?}"
     );
 }
 
-/// When the response includes the requested slug among multiple hits
-/// (for example, a `q=<slug>` query that fans out to similarly-named
-/// datasets), `dataset_by_slug` should pick the exact match rather than
-/// the top-ranked or first hit.
+/// A 200 carrying no results is "no such dataset", the same as a 404.
 #[tokio::test]
-async fn dataset_by_slug_picks_exact_match_among_multiple_hits() {
+async fn dataset_by_slug_returns_none_when_the_response_is_empty() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/search"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
-            "results": [
-                { "slug": "ev-population-history", "title": "Decoy 1" },
-                { "slug": "electric-vehicle-population-data", "title": "Real" },
-                { "slug": "ev-population-by-county",   "title": "Decoy 2" }
-            ],
-            "sort": "relevance"
-        })))
+        .and(path("/api/dataset/nonexistent"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"total": 0, "results": []})))
         .mount(&server)
         .await;
 
-    let client = client_for(&server);
-    let hit = client
-        .dataset_by_slug("electric-vehicle-population-data")
-        .await
-        .unwrap()
-        .expect("exact match should be found");
-    assert_eq!(
-        hit.slug.as_deref(),
-        Some("electric-vehicle-population-data")
+    assert!(
+        client_for(&server)
+            .dataset_by_slug("nonexistent")
+            .await
+            .expect("lookup succeeds")
+            .is_none()
     );
+}
+
+/// The slug goes into a URL *path segment*, so a hostile value must not be able
+/// to steer the request elsewhere. `Url` normalisation resolves `..` after
+/// percent-decoding, so an unencoded slug could reach a different endpoint
+/// entirely.
+///
+/// Asserted by mounting the *only* legitimate path and requiring the request to
+/// land on it: any escape produces a different path, no mock matches, and the
+/// call fails.
+#[tokio::test]
+async fn dataset_by_slug_percent_encodes_hostile_slugs_into_one_path_segment() {
+    for hostile in [
+        "../search",
+        "..%2Fsearch",
+        "a/b",
+        "with space",
+        "quote\"inside",
+        "sem;colon",
+        "q?uery=1",
+        "frag#ment",
+    ] {
+        let server = MockServer::start().await;
+        // Matches any path; we assert on what was actually requested.
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(json!({"total": 0, "results": []})),
+            )
+            .mount(&server)
+            .await;
+
+        let _ = client_for(&server).dataset_by_slug(hostile).await;
+
+        let requests = server.received_requests().await.expect("recorded requests");
+        assert_eq!(requests.len(), 1, "{hostile:?}: exactly one request");
+        let path = requests[0].url.path();
+
+        assert!(
+            path.starts_with("/api/dataset/"),
+            "{hostile:?} escaped the endpoint: requested {path}"
+        );
+        assert_eq!(
+            path.matches('/').count(),
+            3,
+            "{hostile:?} must occupy exactly one path segment, got {path}"
+        );
+        assert!(
+            requests[0].url.query().is_none(),
+            "{hostile:?} must not introduce a query string: {}",
+            requests[0].url
+        );
+    }
 }
 
 #[tokio::test]
@@ -362,4 +383,100 @@ async fn parse_error_surfaces_bad_json() {
     let client = client_for(&server);
     let err = client.organizations().await.unwrap_err();
     assert!(matches!(err, CatalogError::ParseError(_)));
+}
+
+/// The contract nothing in this suite previously pinned: **a slug that exists
+/// resolves**, regardless of whether full-text search recalls it.
+///
+/// The shipped implementation queried `q=<slug>` and scanned the page. A slug
+/// is a lossy derivation of the title — truncated at 90 characters mid-word,
+/// punctuation collapsed, `U.S.` flattened to `u-s` — so its tokens are
+/// frequently absent from the indexed text and the query returns nothing.
+/// Measured against live data.gov: 15% of datasets on a uniform sample, 27%
+/// past cursor depth 400.
+///
+/// This test makes `/search` return zero hits, which is exactly what the live
+/// API does for those slugs. Any implementation that resolves slugs by
+/// full-text search fails here; only one that calls the documented exact-lookup
+/// endpoint passes.
+#[tokio::test]
+async fn dataset_by_slug_resolves_a_slug_that_full_text_search_cannot_recall() {
+    let slug = "advancing-the-automation-of-plant-nucleic-acid-extraction-for-rapid-diagnosis-of-plant-dis";
+    let server = MockServer::start().await;
+
+    // Zero recall, as the live API genuinely returns for this slug: the final
+    // token `dis` is a fragment of "diseases" and appears nowhere in the text.
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [], "sort": "relevance"
+        })))
+        .mount(&server)
+        .await;
+
+    // The documented exact-lookup endpoint, captured verbatim from live.
+    Mock::given(method("GET"))
+        .and(path(format!("/api/dataset/{slug}")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            fixture("dataset_by_slug_truncated.json"),
+            "application/json",
+        ))
+        .mount(&server)
+        .await;
+
+    let hit = client_for(&server)
+        .dataset_by_slug(slug)
+        .await
+        .expect("slug lookup succeeds")
+        .expect("the dataset exists, so it must resolve");
+
+    assert_eq!(
+        hit.slug.as_deref(),
+        Some(slug),
+        "must return the exact slug"
+    );
+    assert!(hit.title.is_some(), "the resolved hit must carry its title");
+}
+
+/// A slug that genuinely does not exist must be `Ok(None)`, not an error and
+/// not a false positive. The endpoint answers 404 with `{"total":0,...}`, and
+/// it does no prefix or substring matching: `nasa-pat` and `nasa-patents-extra`
+/// both 404 against live.
+#[tokio::test]
+async fn dataset_by_slug_returns_none_for_a_slug_that_does_not_exist() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dataset/no-such-dataset-anywhere-12345"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({
+            "detail": {}, "message": "Not Found"
+        })))
+        .mount(&server)
+        .await;
+
+    let outcome = client_for(&server)
+        .dataset_by_slug("no-such-dataset-anywhere-12345")
+        .await;
+
+    assert!(
+        matches!(outcome, Ok(None)),
+        "a missing dataset is Ok(None), not an error: got {outcome:?}"
+    );
+}
+
+/// A 404 means "no such dataset"; every other failure is an error. Reporting a
+/// data.gov outage as a missing dataset is how `cd` came to print
+/// "dataset not found" when the network was simply down.
+#[tokio::test]
+async fn dataset_by_slug_distinguishes_a_server_error_from_a_missing_dataset() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/dataset/some-slug"))
+        .respond_with(ResponseTemplate::new(503).set_body_string("upstream unavailable"))
+        .mount(&server)
+        .await;
+
+    match client_for(&server).dataset_by_slug("some-slug").await {
+        Err(CatalogError::ApiError { status, .. }) => assert_eq!(status, 503),
+        other => panic!("503 must surface as an ApiError, not as a missing dataset: {other:?}"),
+    }
 }

--- a/data-gov-catalog/tests/fixtures/dataset_by_slug.json
+++ b/data-gov-catalog/tests/fixtures/dataset_by_slug.json
@@ -1,0 +1,99 @@
+{
+  "aggregations": null,
+  "results": [
+    {
+      "_score": 0.0,
+      "_sort": null,
+      "dcat": {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "LAPD OpenData",
+          "hasEmail": "mailto:no-reply@data.lacity.org"
+        },
+        "description": "******Notice: Transition to NIBRS-Compliant Crime Data Reporting\nThe Los Angeles Police Department (LAPD) has completed its transition from the legacy Records Management System, which reported crime and arrest data under Uniform Crime Reporting (UCR) standards, to a modernized system fully aligned with the National Incident-Based Reporting System (NIBRS).\nAs part of this transition, the legacy system is no longer active, and no new information will be entered. Consequently, the Crime Data from 2020 to Present dataset will no longer be updated. It will remain available on the portal for historical reference only.\nTo provide the public with current and comprehensive information, LAPD now publishes datasets sourced directly from the new Records Management System in accordance with NIBRS standards. These datasets were introduced in October 2024 and are refreshed on a bi-weekly schedule:\n\u2022\t[LAPD NIBRS Offenses Dataset | Los Angeles Open Data Portal]\n\u2022\t[LAPD NIBRS Victims Dataset | Los Angeles Open Data Portal]\nThe adoption of NIBRS ensures LAPD crime and arrest data meet national standards, enhancing transparency, accuracy, and accessibility for the public.\n******\n\nOn March 7th, 2024, the Los Angeles Police Department (LAPD)  adopted a new Records Management System for reporting crimes and arrests. This new system is implemented to comply with the FBI's mandate to collect NIBRS-only data (NIBRS \u2014 FBI - https://www.fbi.gov/how-we-can-help-you/more-fbi-services-and-information/ucr/nibrs).\n\nThis dataset reflects incidents of crime in the City of Los Angeles dating back to 2020. This data is transcribed from original crime reports that are typed on paper and therefore there may be some inaccuracies within the data. Some location fields with missing data are noted as (0\u00b0, 0\u00b0). Address fields are only provided to the nearest hundred block in order to maintain privacy. This data is as accurate as the data in the database. Please note questions or concerns in the comments.",
+        "distribution": [
+          {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.lacity.org/api/views/2nrs-mtv8/columns.json",
+            "describedByType": "application/json",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/query.json?accessType=DOWNLOAD",
+            "mediaType": "application/json"
+          },
+          {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.lacity.org/api/views/2nrs-mtv8/columns.xml",
+            "describedByType": "application/xml",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/export.xml?accessType=DOWNLOAD",
+            "mediaType": "application/xml"
+          },
+          {
+            "@type": "dcat:Distribution",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/export.csv?accessType=DOWNLOAD",
+            "mediaType": "text/csv"
+          }
+        ],
+        "identifier": "https://data.lacity.org/api/views/2nrs-mtv8",
+        "issued": "2020-02-10",
+        "keyword": [
+          "crime",
+          "crime data",
+          "crimes",
+          "lapd",
+          "police",
+          "safe city"
+        ],
+        "landingPage": "https://data.lacity.org/d/2nrs-mtv8",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+        "modified": "2026-03-04",
+        "publisher": {
+          "@type": "org:Organization",
+          "name": "data.lacity.org"
+        },
+        "theme": [
+          "Public Safety"
+        ],
+        "title": "Crime Data from 2020 to 2024"
+      },
+      "description": "******Notice: Transition to NIBRS-Compliant Crime Data Reporting\nThe Los Angeles Police Department (LAPD) has completed its transition from the legacy Records Management System, which reported crime and arrest data under Uniform Crime Reporting (UCR) standards, to a modernized system fully aligned with the National Incident-Based Reporting System (NIBRS).\nAs part of this transition, the legacy system is no longer active, and no new information will be entered. Consequently, the Crime Data from 2020 to Present dataset will no longer be updated. It will remain available on the portal for historical reference only.\nTo provide the public with current and comprehensive information, LAPD now publishes datasets sourced directly from the new Records Management System in accordance with NIBRS standards. These datasets were introduced in October 2024 and are refreshed on a bi-weekly schedule:\n\u2022\t[LAPD NIBRS Offenses Dataset | Los Angeles Open Data Portal]\n\u2022\t[LAPD NIBRS Victims Dataset | Los Angeles Open Data Portal]\nThe adoption of NIBRS ensures LAPD crime and arrest data meet national standards, enhancing transparency, accuracy, and accessibility for the public.\n******\n\nOn March 7th, 2024, the Los Angeles Police Department (LAPD)  adopted a new Records Management System for reporting crimes and arrests. This new system is implemented to comply with the FBI's mandate to collect NIBRS-only data (NIBRS \u2014 FBI - https://www.fbi.gov/how-we-can-help-you/more-fbi-services-and-information/ucr/nibrs).\n\nThis dataset reflects incidents of crime in the City of Los Angeles dating back to 2020. This data is transcribed from original crime reports that are typed on paper and therefore there may be some inaccuracies within the data. Some location fields with missing data are noted as (0\u00b0, 0\u00b0). Address fields are only provided to the nearest hundred block in order to maintain privacy. This data is as accurate as the data in the database. Please note questions or concerns in the comments.",
+      "distribution_titles": [],
+      "harvest_record": "https://catalog.data.gov/harvest_record/555eedc3-2d49-4f57-910d-8a247addbe6d",
+      "harvest_record_raw": "https://catalog.data.gov/harvest_record/555eedc3-2d49-4f57-910d-8a247addbe6d/raw",
+      "has_spatial": false,
+      "identifier": "https://data.lacity.org/api/views/2nrs-mtv8",
+      "keyword": [
+        "crime",
+        "crime data",
+        "crimes",
+        "lapd",
+        "police",
+        "safe city"
+      ],
+      "last_harvested_date": "2026-07-07T21:23:18.667116",
+      "organization": {
+        "aliases": [
+          "la",
+          "california"
+        ],
+        "description": null,
+        "id": "aa795a1b-5fbb-46d1-b9f2-8b86e1e48bef",
+        "logo": "",
+        "name": "City of Los Angeles",
+        "organization_type": "City Government",
+        "slug": "los-angeles-ca"
+      },
+      "popularity": 2078,
+      "publisher": "data.lacity.org",
+      "slug": "crime-data-from-2020-to-present",
+      "spatial_centroid": null,
+      "spatial_shape": null,
+      "theme": [
+        "Public Safety"
+      ],
+      "title": "Crime Data from 2020 to 2024"
+    }
+  ],
+  "search_after": null,
+  "total": 1
+}

--- a/data-gov-catalog/tests/fixtures/dataset_by_slug_truncated.json
+++ b/data-gov-catalog/tests/fixtures/dataset_by_slug_truncated.json
@@ -1,0 +1,85 @@
+{
+  "aggregations": null,
+  "results": [
+    {
+      "_score": 0.0,
+      "_sort": null,
+      "dcat": {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "bureauCode": [
+          "026:00"
+        ],
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "Open Science Data Repository Help Desk",
+          "hasEmail": "mailto:arc-dl-osdr-help@mail.nasa.gov"
+        },
+        "description": "Human space exploration missions will continue the development of sustainable plant cultivation in what are obviously novel habitat settings. Effective pathology mitigation strategies are needed to cope with plant disease outbreaks in any space-based plant growth system. However, few technologies currently exist for space-based diagnosis of plant pathogens. Therefore, we developed a method of extracting plant nucleic acid that will facilitate the rapid diagnosis of plant diseases for future spaceflight applications. The microHomogenizer from Claremont BioSolutions, originally designed for bacterial and animal tissue samples, was evaluated for plant\u2013microbial nucleic acid extractions. The microHomogenizer is an appealing device in that it provides automation and containment capabilities that would be required in spaceflight applications. Two different plant pathosystems were used to assess the versatility of the extraction process. Tomato and lettuce plants were respectively inoculated with a fungal plant pathogen, an oomycete pathogen, and a plant viral pathogen. The microHomogenizer, along with the developed protocols, proved to be an effective mechanism for producing DNA from two pathosystems, in that PCR and sequencing of the resulting samples demonstrated clear DNA-based diagnoses. Thus, this investigation advances the efforts to automate nucleic acid extraction for future plant disease diagnosis in space.",
+        "distribution": [
+          {
+            "@type": "dcat:Distribution",
+            "downloadURL": "http://purl.bioontology.org/ontology/NCBITAXON/13613",
+            "format": "BIN",
+            "mediaType": "application/octet-stream"
+          },
+          {
+            "@type": "dcat:Distribution",
+            "downloadURL": "https://osdr.nasa.gov/bio/repo/data/studies/OSD-594",
+            "format": "BIN",
+            "mediaType": "application/octet-stream"
+          }
+        ],
+        "identifier": "10.26030/qc04-a934",
+        "keyword": [
+          "__"
+        ],
+        "license": "https://www.usa.gov/government-works",
+        "modified": "2026-06-22",
+        "programCode": [
+          "026:000"
+        ],
+        "publisher": {
+          "@type": "org:Organization",
+          "name": "Open Science Data Repository"
+        },
+        "theme": [
+          "Biological and Physical Sciences"
+        ],
+        "title": "Advancing the automation of plant nucleic acid extraction for rapid diagnosis of plant diseases in space"
+      },
+      "description": "Human space exploration missions will continue the development of sustainable plant cultivation in what are obviously novel habitat settings. Effective pathology mitigation strategies are needed to cope with plant disease outbreaks in any space-based plant growth system. However, few technologies currently exist for space-based diagnosis of plant pathogens. Therefore, we developed a method of extracting plant nucleic acid that will facilitate the rapid diagnosis of plant diseases for future spaceflight applications. The microHomogenizer from Claremont BioSolutions, originally designed for bacterial and animal tissue samples, was evaluated for plant\u2013microbial nucleic acid extractions. The microHomogenizer is an appealing device in that it provides automation and containment capabilities that would be required in spaceflight applications. Two different plant pathosystems were used to assess the versatility of the extraction process. Tomato and lettuce plants were respectively inoculated with a fungal plant pathogen, an oomycete pathogen, and a plant viral pathogen. The microHomogenizer, along with the developed protocols, proved to be an effective mechanism for producing DNA from two pathosystems, in that PCR and sequencing of the resulting samples demonstrated clear DNA-based diagnoses. Thus, this investigation advances the efforts to automate nucleic acid extraction for future plant disease diagnosis in space.",
+      "distribution_titles": [],
+      "harvest_record": "https://catalog.data.gov/harvest_record/3d6075e6-5980-40af-aa74-0a424b0b0599",
+      "harvest_record_raw": "https://catalog.data.gov/harvest_record/3d6075e6-5980-40af-aa74-0a424b0b0599/raw",
+      "has_spatial": false,
+      "identifier": "10.26030/qc04-a934",
+      "keyword": [
+        "__"
+      ],
+      "last_harvested_date": "2026-06-23T21:47:38.565781",
+      "organization": {
+        "aliases": [
+          ""
+        ],
+        "description": null,
+        "id": "f4ca4614-8901-409b-8553-2e994ad10023",
+        "logo": "https://raw.githubusercontent.com/GSA/logo/refs/heads/master/nasa.png",
+        "name": "National Aeronautics and Space Administration",
+        "organization_type": "Federal Government",
+        "slug": "nasa"
+      },
+      "popularity": 15,
+      "publisher": "Open Science Data Repository",
+      "slug": "advancing-the-automation-of-plant-nucleic-acid-extraction-for-rapid-diagnosis-of-plant-dis",
+      "spatial_centroid": null,
+      "spatial_shape": null,
+      "theme": [
+        "Biological and Physical Sciences"
+      ],
+      "title": "Advancing the automation of plant nucleic acid extraction for rapid diagnosis of plant diseases in space"
+    }
+  ],
+  "search_after": null,
+  "total": 1
+}

--- a/data-gov-catalog/tests/integration_tests.rs
+++ b/data-gov-catalog/tests/integration_tests.rs
@@ -83,3 +83,66 @@ async fn live_pagination_advances_with_after_cursor() {
         "pages should not overlap"
     );
 }
+
+/// Live contract test: a slug that exists resolves, including slugs that
+/// full-text search cannot recall.
+///
+/// Each case below is a real data.gov slug that the previous `q=<slug>`
+/// implementation returned `None` for, chosen to span three distinct causes:
+/// 90-character mid-word truncation, punctuation collapse during slugification,
+/// and simple rank overflow past the page cutoff. Measured 1/6 before the fix,
+/// 6/6 after.
+///
+/// Network-bound, so `#[ignore]`d and run by the opt-in Live API Tests job.
+#[tokio::test]
+#[ignore = "hits the live data.gov Catalog API"]
+async fn live_dataset_by_slug_resolves_slugs_full_text_search_cannot_recall() {
+    let client = CatalogClient::new(Arc::new(Configuration::default()));
+
+    for (cause, slug) in [
+        (
+            "90-char truncation mid-word",
+            "advancing-the-automation-of-plant-nucleic-acid-extraction-for-rapid-diagnosis-of-plant-dis",
+        ),
+        (
+            "90-char truncation mid-word",
+            "artemis-p2-ephemeris-heliocentric-trajectories-heliographic-heliographic-inertial-and-sola",
+        ),
+        ("punctuation collapse (Drugs@FDA)", "drugsfda-database"),
+        ("rank overflow past the cutoff", "horizons"),
+        ("rank overflow past the cutoff", "water-quality-data"),
+        ("plain slug, control", "crime-data-from-2020-to-present"),
+    ] {
+        let hit = client
+            .dataset_by_slug(slug)
+            .await
+            .unwrap_or_else(|e| panic!("{cause}: lookup errored for {slug}: {e}"))
+            .unwrap_or_else(|| panic!("{cause}: {slug} exists on data.gov but did not resolve"));
+
+        assert_eq!(
+            hit.slug.as_deref(),
+            Some(slug),
+            "{cause}: resolved a different dataset than requested"
+        );
+    }
+}
+
+/// A slug that does not exist must be `Ok(None)`, and the endpoint must not
+/// prefix-match: `nasa-pat` is a prefix of real slugs and must still miss.
+#[tokio::test]
+#[ignore = "hits the live data.gov Catalog API"]
+async fn live_dataset_by_slug_does_not_prefix_match() {
+    let client = CatalogClient::new(Arc::new(Configuration::default()));
+
+    for absent in ["nasa-pat", "no-such-dataset-anywhere-12345"] {
+        let result = client
+            .dataset_by_slug(absent)
+            .await
+            .unwrap_or_else(|e| panic!("{absent}: lookup errored: {e}"));
+        assert!(
+            result.is_none(),
+            "{absent} does not exist; got {:?}",
+            result.and_then(|h| h.slug)
+        );
+    }
+}

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -212,11 +212,10 @@ async fn dispatch_tools_call_missing_params_returns_invalid_params() {
 #[tokio::test]
 async fn dispatch_direct_tool_method_wraps_response() {
     let mock = MockServer::start().await;
-    // dataset_by_slug uses q=<slug> on the wire (the API doesn't honor slug=)
-    // and matches the slug client-side.
+    // dataset_by_slug resolves through the exact-lookup endpoint
+    // GET /api/dataset/{slug_or_id}, not a full-text search.
     Mock::given(wm_method("GET"))
-        .and(wm_path("/search"))
-        .and(query_param("q", "my-dataset"))
+        .and(wm_path("/api/dataset/my-dataset"))
         .respond_with(
             ResponseTemplate::new(200).set_body_json(search_body("my-dataset", "My Dataset")),
         )
@@ -493,7 +492,7 @@ async fn dispatch_download_resources_rejects_parent_traversal_in_output_dir() {
     // dataset. Include at least one downloadable distribution so the traversal
     // check is the one that fires.
     Mock::given(wm_method("GET"))
-        .and(wm_path("/search"))
+        .and(wm_path("/api/dataset/some-dataset"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "results": [{
                 "slug": "some-dataset",


### PR DESCRIPTION
Targets `release/0.5.0`. Closes #94.

## The bug

`dataset_by_slug` was a **full-text search, not a lookup**. It issued `q=<slug>&per_page=20` and scanned the page — because the `slug=` parameter it was written against never existed. The API's OpenAPI document has no `slug` parameter on `/search` at all, which is exactly why the server ignores it.

A slug is a lossy derivation of the title, so its tokens are often absent from the indexed text and the query returns **nothing**. Against live data.gov:

| Sampling frame | n | Unresolvable |
|---|---:|---|
| Uniform draw from `/search` | 578 | **15.05%** |
| Past cursor depth 400 | 150 | **26.67%** |
| Slugs at the 90-char cap | 600 | **~69%** |

**Truncation is only one of five causes.** Also punctuation collapse (`Drugs@FDA` → `drugsfda`), abbreviation splitting (`U.S.` → `u-s`, breaking the whole TIGER/Line family), hash uniquifier suffixes, and plain rank overflow — `water-quality-data` is at rank 244, `horizons` at 210, both short slugs a user types by hand.

**Raising `per_page` is not a fix**: 83 of 87 failures return *zero* hits, and re-probing 48 of them at `per_page=100` recovered exactly one.

## The fix

`GET /api/dataset/{slug_or_id}` — declared in the API's own OpenAPI document at `/openapi.json`:

```
summary:   gets a single document based on the dataset slug name or dataset id
parameter: slug_or_id (in: path, required)
responses: 200, 404
```

One request, same cost as before. No ranking, no prefix matching. Note this correction to earlier discussion: the endpoint **is** documented — just not on the prose page at resources.data.gov, which omits it. `catalog.data.gov/openapi.json` is the better source and worth consulting first.

**Live: 1/6 known-broken slugs resolved before, 6/6 after**, across three distinct causes.

Two correctness fixes ride along in the same call path:

- **Only a 404 yields `Ok(None)`.** Everything else is an `ApiError`, network failure a `RequestError` — so a data.gov outage stops being reported as a missing dataset.
- **The slug is percent-encoded into one path segment**, so `..`, `%2e` or a slash cannot steer the request elsewhere. `.` is escaped too, so `..` cannot survive as a dot-segment.

## Why no test caught this

All four existing tests supplied the *response* and asked "given this page, pick the right hit" — a property of the workaround. The production failure is a property of the *query*: slug S exists, but `q=S` recalls nothing. That is unrepresentable when the only model of the catalog is the mocked page, and on the wire it was byte-identical to `dataset_by_slug_returns_none_when_empty`, which is why the shape looked covered.

Replaced with tests of the contract, including one that pins what nothing previously did — **S exists → `dataset_by_slug(S)` returns `Some`** — by making `/search` return zero hits, exactly as live does.

Plus live `#[ignore]`d tests over the real broken slugs, and a hostile-input test asserting the request lands on exactly one path segment with no query string.

## Mutation-verified

Every claim checked by reverting it:

| Mutation | Result |
|---|---|
| revert to the `q=<slug>` search | **7 failures** |
| 404 no longer means `Ok(None)` | 1 failure |
| stop percent-encoding the slug | 1 failure |
| drop the slug-equality guard | 1 failure |

## Blast radius

Every entry point that takes a slug: REPL `cd`/`show`/`download`, one-shot CLI, and the `data_gov.dataset` and `data_gov.downloadResources` MCP tools. Two MCP dispatch tests were retargeted to the new endpoint.

Gate green: fmt, clippy `-D warnings`, **202 tests**, docs. `data-gov-catalog/README.md` corrected — it documented this call as `GET /search?slug=…&per_page=1`, a request that returns an unrelated dataset and was never what the code sent.

Not included: #71 removes the dead `SearchParams::slug` builder, now provably unused. Separate breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KoNz3zUgD2n8ckZkCTfdx8