### PR TITLE
fix(cli): survive a reader that closes the pipe early

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
       run: just check-home-paths
       if: matrix.rust == 'stable'
 
+    - name: Check the CLI prints through the broken-pipe-safe macros
+      run: just check-print-macros
+      if: matrix.rust == 'stable'
+
     - name: Check for unused dependencies
       run: just check-deps
       if: matrix.rust == 'stable'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **The CLI no longer panics when a reader closes the pipe early** (#115).
+  `data-gov list organizations | head -5` died with exit 101 and a Rust
+  backtrace note the moment `head` stopped reading, because `println!` panics
+  on a write error. That is one of the most ordinary ways a Unix CLI is used,
+  and every command with enough output was affected, not just this one. The
+  CLI now writes user-facing lines through `outln!` and `errln!`, which
+  recognise `BrokenPipe`: stdout stops the process quietly with exit 0,
+  because a reader that has seen enough is not an error; stderr drops the
+  line and lets the command finish, so a lost stderr cannot overwrite a
+  failing exit code with success. Any other write error stays as loud as it
+  was. The usual `SIGPIPE` fix needs `unsafe`, which this project forbids.
+  `just check-print-macros` now fails the build if a bare `println!` returns
+  to the CLI.
 - **One non-UTF-8 byte no longer ends the MCP session** (#55). `next_line`
   returns an error on invalid UTF-8 and it propagated to `main`, so a single
   malformed byte killed the server for every subsequent well-formed request.

--- a/data-gov/tests/cli_broken_pipe_tests.rs
+++ b/data-gov/tests/cli_broken_pipe_tests.rs
@@ -1,0 +1,124 @@
+//! Process-level tests for #115: a reader that closes the pipe early must
+//! not crash the CLI.
+//!
+//! `data-gov list organizations | head -5` panicked with exit 101 and a
+//! Rust backtrace note, because `println!` panics when the write fails and
+//! `head` closes its end of the pipe after five lines. Piping into a reader
+//! that quits early is one of the most ordinary ways a Unix CLI is used, so
+//! the tool has to survive it.
+//!
+//! Every test here closes the read end of a real pipe *before* the child
+//! writes anything, so the child's first write to stdout fails with
+//! `ErrorKind::BrokenPipe` with no timing race at all. Driving a real
+//! `| head` would depend on whether the child happened to outrun the
+//! reader; this does not.
+//!
+//! The project forbids `unsafe` (CLAUDE.md), which rules out the usual
+//! `signal(SIGPIPE, SIG_DFL)` fix, so the contract under test is the safe
+//! one: recognise the closed pipe at the print boundary and exit quietly.
+
+use std::io::Read;
+use std::process::{Command, Stdio};
+
+/// Path to the `data-gov` binary under test, built by cargo.
+fn data_gov_binary() -> std::path::PathBuf {
+    assert_cmd::cargo::cargo_bin("data-gov")
+}
+
+/// Outcome of running a command with its stdout wired to a pipe whose read
+/// end is already closed.
+struct ClosedPipeRun {
+    status: std::process::ExitStatus,
+    stderr: String,
+}
+
+/// Run `data-gov <args>` with stdout connected to a pipe that has no
+/// reader, and stderr captured.
+///
+/// The read end is dropped before the child is spawned, so there is no
+/// window in which the child could write successfully. `XDG_CONFIG_HOME`
+/// points at an empty directory so the run does not depend on whoever is
+/// running the test having a `config.toml` (#86).
+fn run_with_closed_stdout(args: &[&str]) -> ClosedPipeRun {
+    let config_home = tempfile::tempdir().expect("tempdir");
+    let (reader, writer) = std::io::pipe().expect("create a pipe");
+    drop(reader);
+
+    let mut child = Command::new(data_gov_binary())
+        .args(args)
+        .env("XDG_CONFIG_HOME", config_home.path())
+        .env("NO_PROGRESS", "1")
+        .stdout(Stdio::from(writer))
+        .stderr(Stdio::piped())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("spawn data-gov");
+
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("stderr is piped")
+        .read_to_string(&mut stderr)
+        .expect("read stderr");
+    let status = child.wait().expect("wait for data-gov");
+
+    ClosedPipeRun { status, stderr }
+}
+
+#[test]
+fn a_closed_stdout_pipe_does_not_panic() {
+    let run = run_with_closed_stdout(&["--color", "never", "help"]);
+
+    assert!(
+        !run.stderr.contains("panicked"),
+        "a closed stdout pipe must not panic, got stderr: {}",
+        run.stderr
+    );
+}
+
+#[test]
+fn a_closed_stdout_pipe_exits_zero() {
+    let run = run_with_closed_stdout(&["--color", "never", "help"]);
+
+    assert_eq!(
+        run.status.code(),
+        Some(0),
+        "a reader that quits early is not an error: the command did its job \
+         and the reader stopped listening. Got exit {:?}, stderr: {}",
+        run.status.code(),
+        run.stderr
+    );
+}
+
+#[test]
+fn a_closed_stdout_pipe_prints_no_backtrace_note() {
+    let run = run_with_closed_stdout(&["--color", "never", "help"]);
+
+    assert!(
+        !run.stderr.contains("RUST_BACKTRACE"),
+        "a closed pipe is ordinary Unix usage, not a crash to be debugged; \
+         got stderr: {}",
+        run.stderr
+    );
+}
+
+/// The quiet exit must be specific to a closed pipe, not a blanket
+/// "swallow everything stdout does". An invalid command still has to fail
+/// loudly on stderr, which is a different fd and is still open here.
+#[test]
+fn a_closed_stdout_pipe_does_not_silence_a_real_error() {
+    let run = run_with_closed_stdout(&["--color", "never", "definitely-not-a-real-command-xyz123"]);
+
+    assert!(
+        run.stderr.contains("Error:"),
+        "an unknown command must still report on stderr even when stdout is \
+         closed, got stderr: {}",
+        run.stderr
+    );
+    assert_ne!(
+        run.status.code(),
+        Some(0),
+        "an unknown command must still exit non-zero when stdout is closed"
+    );
+}

--- a/data-gov/tools/cli/ui/colors.rs
+++ b/data-gov/tools/cli/ui/colors.rs
@@ -198,7 +198,7 @@ impl ColorHelper {
 
     /// Apply red color, gated on stderr's terminal state, and return the
     /// finished (possibly ANSI-escaped) string. For text that is about to
-    /// be written with `eprintln!` — user-facing error output must never
+    /// be written with `errln!` — user-facing error output must never
     /// be gated on stdout's TTY state (see the struct-level note), or
     /// redirecting only stderr leaves raw escape sequences in the file.
     ///

--- a/data-gov/tools/cli/ui/display.rs
+++ b/data-gov/tools/cli/ui/display.rs
@@ -1,6 +1,7 @@
 use data_gov::DataGovClient;
 use data_gov::catalog::models::SearchHit;
 
+use super::output::outln;
 use super::{
     color_blue, color_blue_bold, color_bold, color_dimmed, color_green, color_green_bold,
     color_yellow, color_yellow_bold,
@@ -32,37 +33,37 @@ fn padded_green_bold(text: &str, width: usize) -> String {
 
 /// Print dataset details (shared between REPL and CLI modes).
 pub fn print_package_details(hit: &SearchHit) {
-    println!("\n{}", color_blue_bold("📦 Dataset Details"));
+    outln!("\n{}", color_blue_bold("📦 Dataset Details"));
     if let Some(slug) = &hit.slug {
-        println!("{}: {}", color_bold("Slug"), color_yellow(slug));
+        outln!("{}: {}", color_bold("Slug"), color_yellow(slug));
     }
 
     if let Some(title) = &hit.title {
-        println!("{}: {}", color_bold("Title"), title);
+        outln!("{}: {}", color_bold("Title"), title);
     }
 
     if let Some(description) = &hit.description {
-        println!("\n{}: ", color_bold("Description"));
-        println!("{}", color_dimmed(description));
+        outln!("\n{}: ", color_bold("Description"));
+        outln!("{}", color_dimmed(description));
     }
 
     if let Some(dcat) = &hit.dcat
         && let Some(license) = &dcat.license
     {
-        println!("\n{}: {}", color_bold("License"), color_green(license));
+        outln!("\n{}: {}", color_bold("License"), color_green(license));
     }
 
     if let Some(dcat) = &hit.dcat
         && let Some(contact) = &dcat.contact_point
         && let Some(name) = &contact.fn_
     {
-        println!("{}: {}", color_bold("Contact"), name);
+        outln!("{}: {}", color_bold("Contact"), name);
     }
 
     if let Some(org) = &hit.organization
         && let Some(name) = &org.name
     {
-        println!("{}: {}", color_bold("Organization"), name);
+        outln!("{}: {}", color_bold("Organization"), name);
     }
 
     let distributions = hit
@@ -72,7 +73,7 @@ pub fn print_package_details(hit: &SearchHit) {
         .unwrap_or_default();
 
     if !distributions.is_empty() {
-        println!(
+        outln!(
             "\n{} {} downloadable distributions:",
             color_bold("📁"),
             distributions.len()
@@ -86,7 +87,7 @@ pub fn print_package_details(hit: &SearchHit) {
                 .or(dist.media_type.as_deref())
                 .unwrap_or("Unknown");
 
-            println!(
+            outln!(
                 "  {}. {} {}",
                 color_blue_bold(&i.to_string()),
                 color_yellow(title),
@@ -102,36 +103,36 @@ pub fn print_package_details(hit: &SearchHit) {
                 } else {
                     desc.clone()
                 };
-                println!("     {}", color_dimmed(&truncated));
+                outln!("     {}", color_dimmed(&truncated));
             }
         }
 
         if let Some(slug) = &hit.slug {
-            println!(
+            outln!(
                 "\n{} Use 'data-gov download {}' to download all distributions",
                 color_bold("💡"),
                 color_yellow(slug)
             );
-            println!(
+            outln!(
                 "{} Use 'data-gov download {} <index|name>' to download by index or name",
                 color_bold("💡"),
                 color_yellow(slug)
             );
         }
     } else {
-        println!(
+        outln!(
             "\n{} No downloadable distributions found",
             color_yellow("⚠️")
         );
     }
 
-    println!();
+    outln!();
 }
 
 /// Print help for CLI mode.
 pub fn print_cli_help() {
-    println!("\n{}", color_blue_bold("📚 CLI Mode Commands"));
-    println!();
+    outln!("\n{}", color_blue_bold("📚 CLI Mode Commands"));
+    outln!();
 
     let commands = vec![
         (
@@ -163,28 +164,28 @@ pub fn print_cli_help() {
     ];
 
     for (cmd, desc, example) in commands {
-        println!("{} {}", padded_green_bold(cmd, 30), desc);
-        println!(
+        outln!("{} {}", padded_green_bold(cmd, 30), desc);
+        outln!(
             "{:30} {}: data-gov {}",
             "",
             color_dimmed("Example"),
             color_blue(example)
         );
-        println!();
+        outln!();
     }
 
-    println!("{}", color_yellow_bold("💡 Interactive Mode:"));
-    println!(
+    outln!("{}", color_yellow_bold("💡 Interactive Mode:"));
+    outln!(
         "  Run without arguments to start interactive REPL: {}",
         color_blue("data-gov")
     );
-    println!();
+    outln!();
 }
 
 /// Print help for REPL mode.
 pub fn print_repl_help() {
-    println!("\n{}", color_blue_bold("📚 Available Commands"));
-    println!();
+    outln!("\n{}", color_blue_bold("📚 Available Commands"));
+    outln!();
 
     let commands = vec![
         (
@@ -228,58 +229,58 @@ pub fn print_repl_help() {
     ];
 
     for (cmd, desc, example) in commands {
-        println!("{} {}", padded_green_bold(cmd, 25), desc);
-        println!(
+        outln!("{} {}", padded_green_bold(cmd, 25), desc);
+        outln!(
             "{:25} {}: {}",
             "",
             color_dimmed("Example"),
             color_blue(example)
         );
-        println!();
+        outln!();
     }
 
-    println!("{}", color_yellow_bold("💡 Pro Tips:"));
-    println!(
+    outln!("{}", color_yellow_bold("💡 Pro Tips:"));
+    outln!(
         "  • Use short commands: {} for search, {} for show, {} for download",
         color_green("s"),
         color_green("d"),
         color_green("dl")
     );
-    println!(
+    outln!(
         "  • Navigate like a filesystem: {}, {}, {}",
         color_blue("cd epa-gov"),
         color_blue("cd air-quality"),
         color_blue("cd ..")
     );
-    println!(
+    outln!(
         "  • Or jump directly: {}, {}, {}",
         color_blue("cd /epa-gov/air-quality"),
         color_blue("cd /nasa-gov"),
         color_blue("cd /")
     );
-    println!(
+    outln!(
         "  • Then just: {}, {}, {}",
         color_blue("show"),
         color_blue("download 0"),
         color_blue("search pollution")
     );
-    println!(
+    outln!(
         "  • Download multiple distributions: {}",
         color_blue("download \"RDF File\" \"XML File\"")
     );
-    println!(
+    outln!(
         "  • Aliases: {} = {}, {} = {}",
         color_green("select"),
         color_green("cd"),
         color_green("setdir"),
         color_green("lcd")
     );
-    println!("  • Downloads are organized by dataset slug in subdirectories");
-    println!(
+    outln!("  • Downloads are organized by dataset slug in subdirectories");
+    outln!(
         "  • Create scripts with {} for automation",
         color_blue("#!/usr/bin/env data-gov")
     );
-    println!();
+    outln!();
 }
 
 #[cfg(test)]

--- a/data-gov/tools/cli/ui/handlers.rs
+++ b/data-gov/tools/cli/ui/handlers.rs
@@ -8,6 +8,7 @@ use tokio::runtime::Runtime;
 
 use super::commands::{ListingCursor, ReplCommand, SessionContext};
 use super::display::{print_cli_help, print_package_details};
+use super::output::{errln, outln};
 use super::{
     color_blue, color_blue_bold, color_bold, color_cyan, color_dimmed, color_green,
     color_green_bold, color_red, color_red_err, color_yellow, color_yellow_bold,
@@ -218,9 +219,9 @@ fn validate_candidate_exists(
 fn print_select_result(ctx: &SessionContext) {
     let label = ctx.prompt_label();
     if label.is_empty() {
-        println!("{} Selection cleared", color_green_bold("OK"));
+        outln!("{} Selection cleared", color_green_bold("OK"));
     } else {
-        println!(
+        outln!(
             "{} Active context: {}",
             color_green_bold("OK"),
             color_yellow_bold(&label)
@@ -256,7 +257,7 @@ fn handle_search(
     // cases included, so a query that looks like it ends in a number
     // doesn't vanish without explanation.
     if let Some(applied_limit) = limit {
-        println!(
+        outln!(
             "{} {}",
             color_dimmed("Note:"),
             color_dimmed(&trailing_limit_notice(query, applied_limit))
@@ -264,14 +265,14 @@ fn handle_search(
     }
 
     if let Some(org_name) = org.as_deref() {
-        println!(
+        outln!(
             "{} '{}' in org {}...",
             color_cyan("Searching for"),
             query,
             color_yellow(org_name)
         );
     } else {
-        println!("{} '{}'...", color_cyan("Searching for"), query);
+        outln!("{} '{}'...", color_cyan("Searching for"), query);
     }
 
     let page = rt.block_on(client.search(query, Some(effective_limit), None, org.as_deref()))?;
@@ -312,7 +313,7 @@ fn trailing_limit_notice(query: &str, limit: i32) -> String {
 fn print_search_hits(hits: &[data_gov::catalog::models::SearchHit]) {
     for hit in hits {
         let slug = hit.slug.as_deref().unwrap_or("(no-slug)");
-        println!(
+        outln!(
             "{} {}",
             color_yellow_bold(slug),
             color_dimmed(hit.title.as_deref().unwrap_or(""))
@@ -325,7 +326,7 @@ fn print_search_hits(hits: &[data_gov::catalog::models::SearchHit]) {
             } else {
                 description.clone()
             };
-            println!("   {}", color_dimmed(&truncated));
+            outln!("   {}", color_dimmed(&truncated));
         }
     }
 }
@@ -351,7 +352,7 @@ fn listing_summary_line(
 /// Print the standard `Found N <unit>` line, with a `next` hint when more
 /// pages are available (REPL only — see [`listing_summary_line`]).
 fn summarize_listing(count: usize, after: Option<&str>, unit: &str, mode: &OperatingMode) {
-    println!("\n{}", listing_summary_line(count, after, unit, mode));
+    outln!("\n{}", listing_summary_line(count, after, unit, mode));
 }
 
 /// Advance the most recent paginated listing by one page. Errors clearly
@@ -432,7 +433,7 @@ fn handle_show(
     rt: &Runtime,
     dataset_slug: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{} dataset '{}'...", color_cyan("Fetching"), dataset_slug);
+    outln!("{} dataset '{}'...", color_cyan("Fetching"), dataset_slug);
 
     let hit = rt.block_on(client.get_dataset(dataset_slug))?;
     print_package_details(&hit);
@@ -488,13 +489,13 @@ fn handle_download(
         return Err("no dataset specified and none selected (use: select /org/dataset)".into());
     };
 
-    println!("{} dataset '{}'...", color_cyan("Fetching"), dataset_slug);
+    outln!("{} dataset '{}'...", color_cyan("Fetching"), dataset_slug);
 
     let hit = rt.block_on(client.get_dataset(dataset_slug))?;
     let distributions = downloadable_for(&hit)?;
 
     if distributions.is_empty() {
-        println!(
+        outln!(
             "{} No downloadable distributions found in this dataset.",
             color_yellow_bold("Warning:")
         );
@@ -561,7 +562,7 @@ fn download_selected(
     for selector in selectors {
         if let Ok(index) = selector.parse::<usize>() {
             if index >= distributions.len() {
-                eprintln!(
+                errln!(
                     "  {} '{}': index out of range (0-{})",
                     color_red_err("✗"),
                     selector,
@@ -584,7 +585,7 @@ fn download_selected(
                 .collect();
 
             if hits.is_empty() {
-                eprintln!(
+                errln!(
                     "  {} '{}': no matching distribution",
                     color_red_err("✗"),
                     selector
@@ -618,7 +619,7 @@ fn download_selected(
             match result {
                 Ok(path) => {
                     success_paths.insert(path.clone());
-                    println!(
+                    outln!(
                         "  {} {}: {}",
                         color_green("✓"),
                         color_yellow(label),
@@ -627,7 +628,7 @@ fn download_selected(
                 }
                 Err(e) => {
                     download_errors += 1;
-                    eprintln!(
+                    errln!(
                         "  {} {}: {}",
                         color_red_err("✗"),
                         label,
@@ -642,7 +643,7 @@ fn download_selected(
     let error_count = unmatched_selectors + download_errors;
 
     if success_count + error_count > 1 {
-        println!(
+        outln!(
             "\n{} {} downloaded, {} errors",
             color_bold("Summary:"),
             color_green(&success_count.to_string()),
@@ -665,7 +666,7 @@ fn download_selected(
 /// Written to stderr: it only ever prints alongside an error line, as
 /// context for diagnosing that error.
 fn print_available_distributions(distributions: &[Distribution]) {
-    eprintln!("    Available distributions:");
+    errln!("    Available distributions:");
     for (i, d) in distributions.iter().enumerate() {
         let title = d.title.as_deref().unwrap_or("(untitled)");
         let format = d
@@ -673,7 +674,7 @@ fn print_available_distributions(distributions: &[Distribution]) {
             .as_deref()
             .or(d.media_type.as_deref())
             .unwrap_or("?");
-        eprintln!("      {i} {title} [{format}]");
+        errln!("      {i} {title} [{format}]");
     }
 }
 
@@ -692,7 +693,7 @@ fn print_download_summary(
         match result {
             Ok(path) => {
                 success_count += 1;
-                println!(
+                outln!(
                     "  {} Distribution {}: {}",
                     color_green("✓"),
                     i,
@@ -701,7 +702,7 @@ fn print_download_summary(
             }
             Err(e) => {
                 error_count += 1;
-                eprintln!(
+                errln!(
                     "  {} Distribution {}: {}",
                     color_red_err("✗"),
                     i,
@@ -711,7 +712,7 @@ fn print_download_summary(
         }
     }
 
-    println!(
+    outln!(
         "\n{} {} downloaded, {} errors",
         color_bold("Summary:"),
         color_green(&success_count.to_string()),
@@ -776,13 +777,13 @@ fn list_organizations(
     client: &DataGovClient,
     rt: &Runtime,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{} organizations...", color_cyan("Fetching"));
+    outln!("{} organizations...", color_cyan("Fetching"));
     // The org list comes back as a single bulk response (~60-70 orgs);
     // there's no API-level pagination, so show them all.
     let orgs = rt.block_on(client.list_organizations(None))?;
-    println!("\n{} organizations:", color_green_bold("Government"));
+    outln!("\n{} organizations:", color_green_bold("Government"));
     for (i, org) in orgs.iter().enumerate() {
-        println!(
+        outln!(
             "{}. {}",
             color_blue_bold(&format!("{:2}", i + 1)),
             color_yellow(org)
@@ -797,11 +798,11 @@ fn list_org_datasets(
     ctx: &mut SessionContext,
     org: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{} datasets in '{}'...", color_cyan("Fetching"), org);
+    outln!("{} datasets in '{}'...", color_cyan("Fetching"), org);
     let page = rt.block_on(client.search("", Some(DEFAULT_PAGE_SIZE), None, Some(org)))?;
     if page.results.is_empty() {
         ctx.last_listing = None;
-        println!(
+        outln!(
             "{} No datasets found in '{}'.",
             color_yellow_bold("Note:"),
             org
@@ -850,7 +851,7 @@ fn print_dataset_hits(hits: &[data_gov::catalog::models::SearchHit]) {
             format!("  [{}]", tail_parts.join(", "))
         };
 
-        println!(
+        outln!(
             "{} {}{}",
             color_yellow_bold(slug),
             color_dimmed(title),
@@ -864,18 +865,18 @@ fn list_dataset_distributions(
     rt: &Runtime,
     slug: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("{} distributions of '{}'...", color_cyan("Fetching"), slug);
+    outln!("{} distributions of '{}'...", color_cyan("Fetching"), slug);
     let hit = rt.block_on(client.get_dataset(slug))?;
     let distributions = downloadable_for(&hit)?;
     if distributions.is_empty() {
-        println!(
+        outln!(
             "{} No downloadable distributions in '{}'.",
             color_yellow_bold("Note:"),
             slug
         );
         return Ok(());
     }
-    println!(
+    outln!(
         "\n{} {} distributions:",
         color_green_bold("Found"),
         distributions.len()
@@ -891,7 +892,7 @@ fn list_dataset_distributions(
             .as_deref()
             .or(dist.media_type.as_deref())
             .unwrap_or("?");
-        println!(
+        outln!(
             "{}. {} [{}]",
             color_blue_bold(&format!("{:2}", i)),
             color_yellow(title),
@@ -903,22 +904,22 @@ fn list_dataset_distributions(
 
 /// Handle info command.
 fn handle_info(client: &DataGovClient, ctx: &SessionContext) {
-    println!("\n{}", color_blue_bold("📊 Client Information"));
+    outln!("\n{}", color_blue_bold("📊 Client Information"));
     let label = ctx.prompt_label();
     if !label.is_empty() {
-        println!("Active context:    {}", color_yellow_bold(&label));
+        outln!("Active context:    {}", color_yellow_bold(&label));
     }
     if let Some(org) = &ctx.org {
-        println!("Active org:        {}", color_yellow(org));
+        outln!("Active org:        {}", color_yellow(org));
     }
     if let Some(ds) = &ctx.dataset {
-        println!("Active dataset:    {}", color_yellow(ds));
+        outln!("Active dataset:    {}", color_yellow(ds));
     }
-    println!(
+    outln!(
         "Download directory: {}",
         color_blue(&client.download_dir().display().to_string())
     );
-    println!(
+    outln!(
         "Catalog endpoint:  {}",
         color_blue(&client.config().catalog_config.base_path)
     );

--- a/data-gov/tools/cli/ui/mod.rs
+++ b/data-gov/tools/cli/ui/mod.rs
@@ -3,6 +3,7 @@ pub mod colors;
 mod commands;
 mod display;
 mod handlers;
+mod output;
 mod repl;
 mod reporter;
 
@@ -15,6 +16,7 @@ use tokio::runtime::Runtime;
 use self::colors::{ColorHelper, ColorMode};
 use self::commands::{ReplCommand, SessionContext};
 use self::handlers::execute_command;
+use self::output::errln;
 use self::repl::DataGovRepl;
 use self::reporter::CliStatusReporter;
 
@@ -103,7 +105,7 @@ pub fn color_bold(text: &str) -> String {
 }
 
 /// Red, gated on stderr's terminal state. Use for any text about to be
-/// written with `eprintln!` — see [`colors::ColorHelper::red_err`].
+/// written with `errln!` — see [`colors::ColorHelper::red_err`].
 pub fn color_red_err(text: &str) -> String {
     COLOR_HELPER
         .get()
@@ -112,7 +114,7 @@ pub fn color_red_err(text: &str) -> String {
 }
 
 /// Red and bold, gated on stderr's terminal state. Use for any text about
-/// to be written with `eprintln!`.
+/// to be written with `errln!`.
 pub fn color_red_bold_err(text: &str) -> String {
     COLOR_HELPER
         .get()
@@ -199,7 +201,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
         .resolve()?;
 
     for warning in resolved.warnings() {
-        eprintln!("Warning: {warning}");
+        errln!("Warning: {warning}");
     }
 
     let mut config = resolved.into_config();
@@ -209,7 +211,7 @@ pub fn run() -> Result<(), Box<dyn std::error::Error>> {
     if let Some(color_str) = matches.get_one::<String>("color") {
         match color_str.parse::<ColorMode>() {
             Ok(mode) => color_mode = mode,
-            Err(_) => eprintln!("Warning: Invalid color mode '{}', using 'auto'", color_str),
+            Err(_) => errln!("Warning: Invalid color mode '{}', using 'auto'", color_str),
         }
     }
 
@@ -281,7 +283,7 @@ fn run_cli_mode(
         Ok(repl_command) => {
             let mut ctx = SessionContext::default();
             if let Err(e) = execute_command(&client, &rt, repl_command, &mut ctx) {
-                eprintln!("{} {}", color_red_bold_err("Error:"), e);
+                errln!("{} {}", color_red_bold_err("Error:"), e);
                 std::process::exit(1);
             }
         }
@@ -298,12 +300,12 @@ fn run_cli_mode(
 
             if run_as_script {
                 if let Err(e) = run_script_file(&client, &rt, script_path) {
-                    eprintln!("{} {}", color_red_bold_err("Error:"), e);
+                    errln!("{} {}", color_red_bold_err("Error:"), e);
                     std::process::exit(1);
                 }
             } else {
-                eprintln!("{} {}", color_red_bold_err("Error:"), parse_err);
-                eprintln!("Use --help to see available commands and examples");
+                errln!("{} {}", color_red_bold_err("Error:"), parse_err);
+                errln!("Use --help to see available commands and examples");
                 std::process::exit(1);
             }
         }
@@ -359,7 +361,7 @@ fn run_script_file(
         };
 
         if let Err(e) = outcome {
-            eprintln!(
+            errln!(
                 "{} {}:{}: {}",
                 color_red_bold_err("Error:"),
                 path.display(),

--- a/data-gov/tools/cli/ui/output.rs
+++ b/data-gov/tools/cli/ui/output.rs
@@ -1,0 +1,186 @@
+//! User-facing output that survives a reader closing the pipe early.
+//!
+//! `println!` panics when the write fails. Piping into a reader that quits
+//! before the end - `| head`, `| less` closed early, a redirected
+//! descriptor the reader dropped - closes the pipe, every later write
+//! returns [`io::ErrorKind::BrokenPipe`], and the tool dies with exit 101
+//! and a backtrace note over ordinary Unix usage (#115).
+//!
+//! The usual fix restores the default `SIGPIPE` disposition, which needs
+//! `unsafe` and is therefore closed to this project (CLAUDE.md, "No
+//! `unsafe`"). So the closed pipe is recognised here instead, at the one
+//! boundary every user-facing line passes through, and [`outln!`] and
+//! [`errln!`] replace `println!` and `eprintln!` throughout the CLI.
+//! `just check-print-macros` fails the build if a bare `println!` returns.
+//!
+//! The two streams are treated differently on purpose:
+//!
+//! - **stdout** carries the answer. Nobody is reading it any more, so the
+//!   process stops, quietly and successfully. A reader that has seen
+//!   enough is not an error, which is why `ls | head` does not report one.
+//! - **stderr** carries diagnostics. A lost stderr must *not* end the
+//!   process, because the exit code is the only signal a caller has left:
+//!   exiting 0 here would report success for a command that failed. The
+//!   line is dropped and the command finishes and reports as it would
+//!   have.
+//!
+//! Any other write error keeps the old loud behaviour, so a genuinely
+//! broken stdout is still not silent.
+
+use std::fmt::Arguments;
+use std::io::{self, Write};
+
+/// What one write to a user-facing stream did, and what it means for the
+/// process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WriteOutcome {
+    /// The line reached the stream.
+    Written,
+    /// The reader closed its end of the pipe. Nothing further written to
+    /// this stream can be seen by anyone.
+    ReaderGone,
+    /// The write failed for some other reason, which is a real fault and
+    /// must stay loud.
+    Failed(io::ErrorKind),
+}
+
+/// Write one line to `stream` and classify what happened.
+///
+/// Split out from the streams themselves so the classification can be
+/// tested against a writer that fails on demand: the process-level tests
+/// in `tests/cli_broken_pipe_tests.rs` prove the end-to-end behaviour, and
+/// these prove that a closed pipe is told apart from a real fault rather
+/// than everything being swallowed together.
+pub(crate) fn write_line<W: Write>(stream: &mut W, args: Arguments<'_>) -> WriteOutcome {
+    match writeln!(stream, "{args}") {
+        Ok(()) => WriteOutcome::Written,
+        Err(err) if err.kind() == io::ErrorKind::BrokenPipe => WriteOutcome::ReaderGone,
+        Err(err) => WriteOutcome::Failed(err.kind()),
+    }
+}
+
+/// Write one line to stdout, exiting quietly if nobody is reading it.
+///
+/// # Panics
+///
+/// Panics if the write fails for any reason other than a closed pipe,
+/// matching what `println!` did before.
+pub(crate) fn stdout_line(args: Arguments<'_>) {
+    let mut stdout = io::stdout().lock();
+    match write_line(&mut stdout, args) {
+        WriteOutcome::Written => {}
+        // Nobody is reading the answer, so there is no reason to keep
+        // producing it. Exit 0: the command did its job and the reader
+        // stopped listening, which is not a failure.
+        WriteOutcome::ReaderGone => std::process::exit(0),
+        WriteOutcome::Failed(kind) => panic!("failed printing to stdout: {kind}"),
+    }
+}
+
+/// Write one line to stderr, dropping it if nobody is reading it.
+///
+/// # Panics
+///
+/// Panics if the write fails for any reason other than a closed pipe,
+/// matching what `eprintln!` did before.
+pub(crate) fn stderr_line(args: Arguments<'_>) {
+    let mut stderr = io::stderr().lock();
+    match write_line(&mut stderr, args) {
+        WriteOutcome::Written => {}
+        // Deliberately not an exit: see the module docs. The command's own
+        // exit code is the only signal a caller has left once stderr is
+        // gone, and exiting 0 here would overwrite it with "success".
+        WriteOutcome::ReaderGone => {}
+        WriteOutcome::Failed(kind) => panic!("failed printing to stderr: {kind}"),
+    }
+}
+
+/// Print a line to stdout, exiting quietly if the reader has closed the
+/// pipe. Drop-in replacement for `println!`.
+macro_rules! outln {
+    () => {
+        $crate::ui::output::stdout_line(::std::format_args!(""))
+    };
+    ($($arg:tt)*) => {
+        $crate::ui::output::stdout_line(::std::format_args!($($arg)*))
+    };
+}
+
+/// Print a line to stderr, dropping it if the reader has closed the pipe.
+/// Drop-in replacement for `eprintln!`.
+macro_rules! errln {
+    () => {
+        $crate::ui::output::stderr_line(::std::format_args!(""))
+    };
+    ($($arg:tt)*) => {
+        $crate::ui::output::stderr_line(::std::format_args!($($arg)*))
+    };
+}
+
+pub(crate) use {errln, outln};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A writer that fails every write with a chosen error kind.
+    struct FailingWriter(io::ErrorKind);
+
+    impl Write for FailingWriter {
+        fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+            Err(io::Error::new(self.0, "write refused by the test writer"))
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Err(io::Error::new(self.0, "flush refused by the test writer"))
+        }
+    }
+
+    #[test]
+    fn a_write_that_succeeds_reports_written_and_appends_a_newline() {
+        let mut sink = Vec::new();
+
+        let outcome = write_line(&mut sink, format_args!("dataset {}", 7));
+
+        assert_eq!(outcome, WriteOutcome::Written);
+        assert_eq!(String::from_utf8(sink).expect("utf-8"), "dataset 7\n");
+    }
+
+    #[test]
+    fn a_broken_pipe_reports_the_reader_is_gone() {
+        let mut stream = FailingWriter(io::ErrorKind::BrokenPipe);
+
+        let outcome = write_line(&mut stream, format_args!("anything"));
+
+        assert_eq!(outcome, WriteOutcome::ReaderGone);
+    }
+
+    /// The quiet path must be specific to a closed pipe. Treating every
+    /// write error as "the reader left" would turn a full disk or a
+    /// revoked descriptor into a silent, successful exit.
+    ///
+    /// `ErrorKind::Interrupted` is deliberately absent: `Write::write_fmt`
+    /// retries it rather than returning it, so it never reaches this
+    /// classification. Including it here hung the test forever against a
+    /// writer that always fails.
+    #[test]
+    fn any_other_write_error_reports_a_failure_rather_than_a_gone_reader() {
+        for kind in [
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::StorageFull,
+            io::ErrorKind::WriteZero,
+            io::ErrorKind::InvalidInput,
+        ] {
+            let mut stream = FailingWriter(kind);
+
+            let outcome = write_line(&mut stream, format_args!("anything"));
+
+            assert_eq!(
+                outcome,
+                WriteOutcome::Failed(kind),
+                "{kind:?} is a real fault and must stay loud, not be mistaken \
+                 for a reader that closed the pipe"
+            );
+        }
+    }
+}

--- a/data-gov/tools/cli/ui/repl.rs
+++ b/data-gov/tools/cli/ui/repl.rs
@@ -8,6 +8,7 @@ use tokio::runtime::Runtime;
 use super::commands::{ReplCommand, SessionContext};
 use super::display::print_repl_help;
 use super::handlers::execute_command;
+use super::output::outln;
 use super::{color_blue, color_blue_bold, color_dimmed, color_green_bold, color_red_bold};
 use data_gov::DataGovClient;
 
@@ -69,12 +70,12 @@ impl DataGovRepl {
     }
 
     pub fn run(&mut self) -> RustyResult<()> {
-        println!("{}", color_blue_bold("🇺🇸 Data.gov Interactive Explorer"));
-        println!(
+        outln!("{}", color_blue_bold("🇺🇸 Data.gov Interactive Explorer"));
+        outln!(
             "{}",
             color_dimmed("Type 'help' for available commands, 'quit' to exit")
         );
-        println!();
+        outln!();
 
         let mut rl = DefaultEditor::new()?;
 
@@ -123,29 +124,29 @@ impl DataGovRepl {
                 match ReplCommand::from_str(&line) {
                     Ok(command) => {
                         if let ReplCommand::Quit = command {
-                            println!("Goodbye! 👋");
+                            outln!("Goodbye! 👋");
                             return Ok(LoopControl::Stop);
                         }
 
                         if let Err(e) = self.handle_command(command) {
-                            println!("{} {}", color_red_bold("Error:"), e);
+                            outln!("{} {}", color_red_bold("Error:"), e);
                         }
                     }
                     Err(e) => {
-                        println!("{} {}", color_red_bold("Invalid command:"), e);
+                        outln!("{} {}", color_red_bold("Invalid command:"), e);
                     }
                 }
 
                 Ok(LoopControl::Continue)
             }
             LoopAction::Reprompt => {
-                println!("CTRL-C");
+                outln!("CTRL-C");
                 // Must keep looping — this is the exact wiring decision
                 // that regressed to `break` under #69.4.
                 Ok(LoopControl::Continue)
             }
             LoopAction::Exit(msg) => {
-                println!("{msg}");
+                outln!("{msg}");
                 Ok(LoopControl::Stop)
             }
         }
@@ -200,7 +201,7 @@ impl DataGovRepl {
             Ok::<(), data_gov::DataGovError>(())
         })?;
 
-        println!(
+        outln!(
             "{} Download directory set to: {}",
             color_green_bold("Success!"),
             color_blue(&path.display().to_string())

--- a/data-gov/tools/cli/ui/reporter.rs
+++ b/data-gov/tools/cli/ui/reporter.rs
@@ -10,6 +10,7 @@ use data_gov::ui::{
 };
 
 use super::colors::ColorHelper;
+use super::output::{errln, outln};
 use super::{color_cyan, color_red_bold};
 
 pub struct CliStatusReporter {
@@ -108,10 +109,10 @@ impl StatusReporter for CliStatusReporter {
 
         if self.fancy_progress {
             if let Err(e) = self.multi.println(&msg) {
-                eprintln!("{msg} (progress display error: {e})");
+                errln!("{msg} (progress display error: {e})");
             }
         } else {
-            println!("{msg}");
+            outln!("{msg}");
         }
     }
 
@@ -127,9 +128,9 @@ impl StatusReporter for CliStatusReporter {
             let key = Self::bar_key(&event.output_path);
             self.lock_bars().insert(key, pb);
         } else if let Some(total) = event.total_bytes {
-            println!("Downloading {} ({} bytes)...", name, total);
+            outln!("Downloading {} ({} bytes)...", name, total);
         } else {
-            println!("Downloading {} ...", name);
+            outln!("Downloading {} ...", name);
         }
     }
 
@@ -159,7 +160,7 @@ impl StatusReporter for CliStatusReporter {
         }
 
         if self.show_progress {
-            println!("{} {}", self.color_helper.green("✓ Downloaded"), name);
+            outln!("{} {}", self.color_helper.green("✓ Downloaded"), name);
         }
     }
 
@@ -192,10 +193,10 @@ impl StatusReporter for CliStatusReporter {
             // No bar found — fall through to plain print
             let msg = format!("{} {} ({})", color_red_bold("✗"), display, event.error);
             if let Err(e) = self.multi.println(&msg) {
-                eprintln!("{msg} (progress display error: {e})");
+                errln!("{msg} (progress display error: {e})");
             }
         } else {
-            println!(
+            outln!(
                 "{} {} ({})",
                 color_red_bold("Failed:"),
                 display,

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ default:
     @just --list
 
 # The full gate. Run this before you push.
-check: fmt-check check-ascii check-home-paths check-deps lint build test check-rustls examples docs
+check: fmt-check check-ascii check-home-paths check-print-macros check-deps lint build test check-rustls examples docs
 
 # Format every file in place.
 fmt:
@@ -50,6 +50,13 @@ check-ascii:
 check-home-paths:
     python3 scripts/check-home-paths.py --self-test
     python3 scripts/check-home-paths.py
+
+# Fail if the CLI prints with `println!`/`eprintln!`, which panic when the
+# reader closes the pipe (#115). `outln!`/`errln!` handle that; see
+# data-gov/tools/cli/ui/output.rs.
+check-print-macros:
+    python3 scripts/check-print-macros.py --self-test
+    python3 scripts/check-print-macros.py
 
 # Fail if a crate declares a dependency nothing imports.
 #

--- a/scripts/check-print-macros.py
+++ b/scripts/check-print-macros.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Fail if the CLI writes user-facing output with `println!` or `eprintln!`.
+
+`println!` panics when the write fails, so piping the CLI into a reader that
+quits early - `data-gov list organizations | head -5` - killed the process with
+exit 101 and a backtrace note over ordinary Unix usage (#115). The fix routes
+every user-facing line through `outln!` and `errln!` in
+`data-gov/tools/cli/ui/output.rs`, which recognise a closed pipe and stop
+quietly.
+
+That fix holds only while it is complete. One `println!` added later reopens
+the defect on whichever command it prints from, and nothing else would notice:
+the code compiles, the tests pass, and the crash appears only when somebody
+pipes that particular command into `head`. So the absence of the bare macros is
+checked here rather than remembered.
+
+Comment lines are exempt, because `output.rs` documents the macros it replaces
+by name.
+
+Run with --self-test to check the matcher itself against the cases below. The
+gate runs that first, so a change that breaks the matcher fails immediately
+rather than silently passing everything.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+# The four std printing macros, each of which panics on a write error. The
+# lookbehind keeps `my_println!` and similar from matching on their tail.
+PRINT_MACRO_RE = re.compile(r"(?<!\w)e?print(?:ln)?!")
+
+# Only the CLI binary is covered. The library crates do not print to the
+# user's terminal; they report through `data_gov::ui::StatusReporter`.
+SCANNED_PREFIX = "data-gov/tools/cli/"
+
+SELF_TEST_CASES: list[tuple[str, bool]] = [
+    # (line, is it a violation?)
+    ('    println!("Government organizations:");', True),
+    ('    eprintln!("Error: {err}");', True),
+    ('    print!("no newline");', True),
+    ('    eprint!("no newline");', True),
+    ("    println!();", True),
+    # The replacements, which are the whole point.
+    ('    outln!("Government organizations:");', False),
+    ('    errln!("Error: {err}");', False),
+    ("    outln!();", False),
+    # Documentation naming the macros it replaces.
+    ("//! `println!` panics when the write fails.", False),
+    ("/// Drop-in replacement for `eprintln!`.", False),
+    ("    /// be written with `eprintln!` - user-facing error output", False),
+    # Identifiers that merely end in a covered name.
+    ('    my_println!("x");', False),
+    ('    sprint!("x");', False),
+]
+
+
+def is_violation(line: str) -> bool:
+    """True if `line` calls a bare std printing macro.
+
+    A line whose first non-space characters are `//` is documentation, and
+    documentation is allowed to name the macros.
+    """
+    if line.lstrip().startswith("//"):
+        return False
+    return PRINT_MACRO_RE.search(line) is not None
+
+
+def self_test() -> int:
+    failures = 0
+    for line, expected in SELF_TEST_CASES:
+        actual = is_violation(line)
+        if actual != expected:
+            failures += 1
+            print(
+                f"self-test: {line!r} -> {actual}, expected {expected}",
+                file=sys.stderr,
+            )
+    if failures:
+        print(f"{failures} self-test case(s) failed.", file=sys.stderr)
+        return 1
+    print(f"check-print-macros self-test: {len(SELF_TEST_CASES)} cases pass.")
+    return 0
+
+
+def tracked_cli_sources() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", f"{SCANNED_PREFIX}*.rs"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [path for path in out.stdout.splitlines() if path]
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    sources = tracked_cli_sources()
+    if not sources:
+        print(
+            f"::error::no tracked .rs files under {SCANNED_PREFIX}. The CLI "
+            "moved, so this check is scanning nothing - point it at the new "
+            "location.",
+            file=sys.stderr,
+        )
+        return 1
+
+    findings = 0
+    for path in sources:
+        with open(path, encoding="utf-8") as handle:
+            for number, line in enumerate(handle, start=1):
+                if is_violation(line):
+                    findings += 1
+                    print(f"{path}:{number}: {line.rstrip()}", file=sys.stderr)
+
+    if findings:
+        print(
+            f"\n{findings} bare printing macro(s) above. `println!` and "
+            "`eprintln!` panic when the reader closes the pipe (#115). Use "
+            "`outln!` and `errln!` from `data-gov/tools/cli/ui/output.rs` "
+            "instead.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"check-print-macros: {len(sources)} CLI source file(s) clean.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the panic in #115.

## Problem

`data-gov list organizations | head -5` panicked with exit 101 and a Rust
backtrace note the moment `head` stopped reading:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1166:9:
failed printing to stdout: Broken pipe (os error 32)
```

`println!` panics when the write fails, and a closed pipe makes every
later write fail. Piping into a reader that quits early is one of the
most ordinary ways a Unix CLI is used. This was not limited to `list
organizations` - every command with enough output was affected, across
roughly 100 print sites.

## Approach

The usual fix restores the default `SIGPIPE` disposition, which needs
`unsafe` and is closed to this project. `#[unix_sigpipe]` was checked
against the actual toolchain (rustc 1.97.1) and does not exist, so it is
not an option either.

So the closed pipe is recognised at the print boundary instead. `outln!`
and `errln!` in the new `data-gov/tools/cli/ui/output.rs` replace
`println!` and `eprintln!` across the CLI.

**The two streams are treated differently on purpose:**

- **stdout** carries the answer. A gone reader stops the process quietly
  with exit 0 - a reader that has seen enough is not an error, which is
  why `ls | head` reports none.
- **stderr** carries diagnostics. A gone reader only drops the line.
  Exiting 0 there would overwrite a failing command's exit code with
  success, and that code is the only signal a caller has left.

Any other write error keeps the old loud behaviour, so a genuinely
broken stdout is still not silent.

## Enforcement

`just check-print-macros` (new, wired into `just check` and CI) fails
the build if a bare printing macro returns to the CLI. This fix holds
only while it is complete: one `println!` added later would reopen the
defect on whichever command it prints from, and nothing else would
notice - the code compiles, the tests pass, and the crash appears only
when somebody pipes that command into `head`.

The script carries a `--self-test` that the gate runs first, matching
the existing `check-home-paths.py` convention. The guard was proved to
fire by reintroducing a `println!` and watching it exit 1.

## Tests

Four process-level tests in `data-gov/tests/cli_broken_pipe_tests.rs`
plus three unit tests on the classifier.

The process tests close the read end of a real pipe *before* the child
is spawned, so the child's first write fails with `BrokenPipe` with no
timing race at all. Driving a real `| head` would depend on whether the
child happened to outrun the reader; this does not.

They were written first and confirmed red for the right reason (exit
101, `failed printing to stdout: Broken pipe`). One of the four -
`a_closed_stdout_pipe_does_not_silence_a_real_error` - passed before the
fix and still passes, deliberately: it guards against over-fixing by
proving an unknown command still reports on stderr and exits non-zero
when stdout is closed.

Verified end-to-end against the live API:

```
$ data-gov list organizations | head -5
Fetching organizations...

Government organizations:
 1. census
 2. noaa
exit=0
```

## Limits of what was checked

- The sweep covered `data-gov/tools/cli/`, which is the only place in
  the workspace that prints to the user's terminal. The library crates
  report through `data_gov::ui::StatusReporter`; `check-print-macros`
  scans the CLI only and fails loudly if that directory ever stops
  existing.
- `indicatif` progress bars were checked and are not a second path to
  this bug: the reporter hides the draw target when stdout is not a
  terminal, so nothing is written in the piped case.
- `ErrorKind::Interrupted` is deliberately absent from the classifier
  test - `Write::write_fmt` retries it rather than returning it, so it
  never reaches classification. Including it hung the test forever
  against an always-failing writer.

Refs #115