### PR TITLE
Close #59's documentation and lint gaps, except the ckan sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **`DataGovError::sanitized_message` no longer leaks the paths it promises to
+  remove** (#59). It documented itself as stripping filesystem paths, had no
+  test and no caller, and stripped only tokens that began with `/` or `./`.
+  Everything else went through untouched: a path containing a space kept the
+  half that names the file, `../secrets/key.txt` and `~/secrets/key.txt` were
+  passed through whole, and a quoted path - the shape error messages use most
+  often - defeated the check entirely, because the token began with a quote.
+  It now redacts a path wherever it appears and however it is punctuated,
+  keeping the surrounding punctuation. URLs still survive, since a public
+  catalog URL is usually what makes a failure actionable and discloses nothing
+  about the machine; `file://` does not, being a path wearing a scheme. Prose
+  such as `read/write` and `and/or` survives too.
 - **One non-UTF-8 byte no longer ends the MCP session** (#55). `next_line`
   returns an error on invalid UTF-8 and it propagated to `main`, so a single
   malformed byte killed the server for every subsequent well-formed request.
@@ -401,6 +413,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `data_gov::catalog` re-export. The lockfile drops from 308 to 279 crates.
 
 ### Infrastructure
+- **`clippy::missing_errors_doc` and `clippy::missing_panics_doc` are denied
+  workspace-wide** (#59), and the 24 public `Result`-returning functions that
+  had no `# Errors` section now have one naming the variants that call path can
+  actually produce. CLAUDE.md required the section; nothing enforced it, so it
+  was missing across three crates.
 
 - **Working docs are plain ASCII, and CI enforces it.** `CLAUDE.md` and the
   `justfile` used em-dashes and arrow glyphs throughout - characters nobody

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Error::downcast_mut()`.
 
 ### Added
+- **`data_gov::ui` is documented** (#59). The download progress-reporting port
+  - [`StatusReporter`] and its five event structs - carried no documentation at
+  all, so a consumer implementing it had to read the client's source to learn
+  the event order, that every method has a do-nothing default, that
+  `total_bytes: None` means unknown rather than empty, and that a blocking
+  implementation stalls the transfer that called it. All of that is now stated,
+  with an example.
 - MCP `ping` and `notifications/cancelled`. Cancelling drops the in-flight
   handler and sends no response, as the spec requires.
 - `util::join_inside` in `data-gov`, which joins a component onto a directory and
@@ -418,6 +425,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   had no `# Errors` section now have one naming the variants that call path can
   actually produce. CLAUDE.md required the section; nothing enforced it, so it
   was missing across three crates.
+- **`missing_docs` is denied in `data-gov-catalog`, `data-gov`, and
+  `data-gov-mcp-server`** (#59), clearing 100 undocumented public items: the 60
+  DCAT-US 3 model fields in the catalog crate, and in `data-gov` the whole
+  `ui` module, the error variants' fields, and the `client` and `error` module
+  docs. `data-gov-ckan` is deliberately not covered yet - its 170 model fields
+  are tracked in #118, and it is the crate data.gov no longer uses.
 
 - **Working docs are plain ASCII, and CI enforces it.** `CLAUDE.md` and the
   `justfile` used em-dashes and arrow glyphs throughout - characters nobody

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,5 @@ warnings = "deny"
 
 [workspace.lints.clippy]
 all = "deny"
+missing_errors_doc = "deny"
+missing_panics_doc = "deny"

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -610,6 +610,13 @@ impl CatalogClient {
     ///
     /// The endpoint returns the full list in one response; there is no
     /// pagination today.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn organizations(&self) -> Result<models::OrganizationsResponse, CatalogError> {
         self.get_json("/api/organizations", &[(); 0]).await
     }
@@ -618,6 +625,13 @@ impl CatalogClient {
     ///
     /// `size` caps the number of rows (server default 100, max 1000).
     /// `min_count` drops keywords with fewer than that many datasets.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn keywords(
         &self,
         size: Option<i32>,
@@ -634,6 +648,13 @@ impl CatalogClient {
     }
 
     /// Autocomplete against known locations.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn locations_search(
         &self,
         q: &str,
@@ -651,12 +672,34 @@ impl CatalogClient {
     /// The response is returned as a raw [`serde_json::Value`] because the
     /// shape is unconstrained GeoJSON and callers typically hand it straight
     /// to a mapping library.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::InvalidPathSegment`] before any request is
+    /// made if `id` cannot be carried safely in a URL path segment - a
+    /// value that normalizes away would silently retarget the request.
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn location_geometry(&self, id: &str) -> Result<Value, CatalogError> {
         let path = format!("/api/location/{}", encode_path_segment(id)?);
         self.get_json(&path, &[(); 0]).await
     }
 
     /// Retrieve a harvest record's metadata envelope.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::InvalidPathSegment`] before any request is
+    /// made if `id` cannot be carried safely in a URL path segment - a
+    /// value that normalizes away would silently retarget the request.
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn harvest_record(&self, id: &str) -> Result<models::HarvestRecord, CatalogError> {
         let path = format!("/harvest_record/{}", encode_path_segment(id)?);
         self.get_json(&path, &[(); 0]).await
@@ -667,6 +710,17 @@ impl CatalogClient {
     /// The payload is not constrained to a single shape — agencies post JSON,
     /// XML fragments, and DCAT records through the same surface — so the
     /// result is returned as [`serde_json::Value`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CatalogError::InvalidPathSegment`] before any request is
+    /// made if `id` cannot be carried safely in a URL path segment - a
+    /// value that normalizes away would silently retarget the request.
+    ///
+    /// Returns [`CatalogError::RequestError`] if the request cannot be sent
+    /// or its body cannot be read, [`CatalogError::ApiError`] for any
+    /// non-2xx status, and [`CatalogError::ParseError`] if the body is not
+    /// the shape this endpoint returns.
     pub async fn harvest_record_raw(&self, id: &str) -> Result<Value, CatalogError> {
         let path = format!("/harvest_record/{}/raw", encode_path_segment(id)?);
         self.get_json(&path, &[(); 0]).await

--- a/data-gov-catalog/src/lib.rs
+++ b/data-gov-catalog/src/lib.rs
@@ -25,6 +25,9 @@
 //! # Ok(()) }
 //! ```
 
+// Every public item in this crate carries a doc comment, and that is
+// enforced rather than remembered (#59).
+#![deny(missing_docs)]
 // A TLS backend is not optional: every endpoint this crate talks to is HTTPS.
 // Without one, reqwest builds an HTTP-only connector, the crate compiles clean,
 // and the first request fails at connect with "invalid URL, scheme is not http".

--- a/data-gov-catalog/src/models.rs
+++ b/data-gov-catalog/src/models.rs
@@ -109,8 +109,10 @@ pub struct Dataset {
     /// DCAT type hint, typically `"dcat:Dataset"`.
     #[serde(default, rename = "@type", skip_serializing_if = "Option::is_none")]
     pub type_hint: Option<String>,
+    /// Human-readable name of the dataset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Human-readable description of the dataset, as plain text.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Publisher-assigned identifier.
@@ -129,16 +131,21 @@ pub struct Dataset {
     /// ISO 8601 date the record was first issued.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub issued: Option<String>,
+    /// Organization that published the dataset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub publisher: Option<Publisher>,
+    /// Person or role to contact about the dataset.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "contactPoint"
     )]
     pub contact_point: Option<ContactPoint>,
+    /// Publisher-assigned tags. Free-form, and not drawn from any
+    /// controlled vocabulary.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub keyword: Vec<String>,
+    /// Broad subject categories the publisher assigned.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub theme: Vec<String>,
     /// Downloadable / accessible representations of the dataset.
@@ -151,28 +158,45 @@ pub struct Dataset {
         rename = "landingPage"
     )]
     pub landing_page: Option<String>,
+    /// URL of the licence the dataset is released under.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
+    /// Explanation of who may access the dataset, where
+    /// [`Self::access_level`] is not `public`. Publishers send both
+    /// prose and single tokens such as `otherRestrictions` here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rights: Option<String>,
+    /// Geographic coverage, as a place name or as a comma-separated
+    /// bounding box (`west,south,east,north`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub spatial: Option<String>,
+    /// Period the data covers, as an ISO 8601 interval.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temporal: Option<String>,
+    /// How often the dataset is updated, as an ISO 8601 duration.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "accrualPeriodicity"
     )]
     pub accrual_periodicity: Option<String>,
+    /// Languages the dataset is available in, as IETF language tags.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub language: Vec<String>,
+    /// OMB bureau codes for the publishing agency, in `NNN:NN` form.
+    ///
+    /// Untyped because publishers are not consistent about whether
+    /// this arrives as a single string or an array of them, and a
+    /// strict type here would fail the whole record over one
+    /// publisher's choice.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "bureauCode"
     )]
     pub bureau_code: Option<Value>,
+    /// OMB program codes, in `NNN:NNN` form. Untyped for the same
+    /// reason as [`Self::bureau_code`].
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -186,20 +210,26 @@ pub struct Dataset {
         rename = "describedBy"
     )]
     pub described_by: Option<String>,
+    /// Media type of the resource at [`Self::described_by`].
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "describedByType"
     )]
     pub described_by_type: Option<String>,
+    /// URLs of related documents.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub references: Vec<String>,
+    /// Whether the publisher asserts the dataset meets its agency's
+    /// information-quality guidelines.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "dataQuality"
     )]
     pub data_quality: Option<bool>,
+    /// URL of the Privacy Act system-of-records notice covering the
+    /// dataset, where one applies.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -211,10 +241,13 @@ pub struct Dataset {
 /// One downloadable or API-accessible representation of a dataset.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Distribution {
+    /// DCAT type hint, typically `"dcat:Distribution"`.
     #[serde(default, rename = "@type", skip_serializing_if = "Option::is_none")]
     pub type_hint: Option<String>,
+    /// Human-readable name of this distribution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// Human-readable description of this distribution.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Direct download URL for the distribution file.
@@ -233,14 +266,18 @@ pub struct Distribution {
     /// Short format label (e.g. `CSV`, `JSON`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
+    /// URL of the licence this distribution is released under, where
+    /// it differs from the dataset's.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<String>,
+    /// URL of a schema or data dictionary for this distribution.
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
         rename = "describedBy"
     )]
     pub described_by: Option<String>,
+    /// Media type of the resource at [`Self::described_by`].
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",
@@ -252,8 +289,10 @@ pub struct Distribution {
 /// DCAT publisher object (`org:Organization`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Publisher {
+    /// DCAT type hint, typically `"org:Organization"`.
     #[serde(default, rename = "@type", skip_serializing_if = "Option::is_none")]
     pub type_hint: Option<String>,
+    /// Name of the organization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Nested publisher (parent organization).
@@ -268,6 +307,7 @@ pub struct Publisher {
 /// DCAT contact point (`vcard:Contact`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContactPoint {
+    /// DCAT type hint, typically `"vcard:Contact"`.
     #[serde(default, rename = "@type", skip_serializing_if = "Option::is_none")]
     pub type_hint: Option<String>,
     /// Full name of the contact.
@@ -294,8 +334,11 @@ impl ContactPoint {
 /// Envelope returned by `/api/organizations`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OrganizationsResponse {
+    /// Every organization the catalog knows about. This endpoint
+    /// returns the full list in one response.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub organizations: Vec<Organization>,
+    /// Number of organizations in [`Self::organizations`].
     #[serde(default)]
     pub total: i64,
 }
@@ -303,22 +346,38 @@ pub struct OrganizationsResponse {
 /// A publishing organization as the catalog knows it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Organization {
+    /// Catalog-internal identifier.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Display name of the organization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// URL-friendly identifier, and the value
+    /// [`SearchParams::org_slug`](crate::SearchParams::org_slug)
+    /// filters on.
+    ///
+    /// Read it from here rather than guessing it from the name: the
+    /// slug for NOAA is `noaa`, not `noaa-gov`, and the API answers a
+    /// wrong slug with an empty result rather than an error.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub slug: Option<String>,
+    /// Human-readable description of the organization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// URL of the organization's logo.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub logo: Option<String>,
+    /// Category the catalog assigns to the organization, such as the
+    /// level of government it belongs to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub organization_type: Option<String>,
+    /// Number of datasets the organization publishes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dataset_count: Option<i64>,
+    /// Number of harvest sources the organization operates.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_count: Option<i64>,
+    /// Other names the organization is known by.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub aliases: Vec<String>,
 }
@@ -326,12 +385,18 @@ pub struct Organization {
 /// Envelope returned by `/api/keywords`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeywordsResponse {
+    /// Keywords ranked by the number of datasets carrying them,
+    /// most frequent first.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub keywords: Vec<KeywordCount>,
+    /// Number of keywords in [`Self::keywords`].
     #[serde(default)]
     pub total: i64,
+    /// Row cap the server applied, echoing the requested `size`.
     #[serde(default)]
     pub size: i64,
+    /// Minimum dataset count a keyword needed to be included,
+    /// echoing the requested `min_count`.
     #[serde(default)]
     pub min_count: i64,
 }
@@ -339,17 +404,22 @@ pub struct KeywordsResponse {
 /// One keyword entry with its document-frequency count.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeywordCount {
+    /// The keyword itself.
     pub keyword: String,
+    /// Number of datasets carrying this keyword.
     pub count: i64,
 }
 
 /// Envelope returned by `/api/locations/search`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LocationsResponse {
+    /// Matching locations, best match first.
     #[serde(default, deserialize_with = "deserialize_null_as_default")]
     pub locations: Vec<Location>,
+    /// Number of locations in [`Self::locations`].
     #[serde(default)]
     pub total: i64,
+    /// Row cap the server applied, echoing the requested `size`.
     #[serde(default)]
     pub size: i64,
 }
@@ -357,7 +427,11 @@ pub struct LocationsResponse {
 /// A location suggestion.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Location {
+    /// Identifier to pass to
+    /// [`CatalogClient::location_geometry`](crate::CatalogClient::location_geometry)
+    /// to fetch this location's GeoJSON.
     pub id: String,
+    /// Human-readable place name.
     pub display_name: String,
 }
 
@@ -365,26 +439,44 @@ pub struct Location {
 /// distinct from the transformed DCAT payload).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct HarvestRecord {
+    /// Identifier of this harvest record.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Identifier this dataset carried in the retired CKAN catalog,
+    /// where it had one.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ckan_id: Option<String>,
+    /// Publisher-assigned identifier of the harvested dataset, which
+    /// is the same value as the DCAT record's `identifier`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identifier: Option<String>,
+    /// Identifier of the parent record, for a dataset harvested as
+    /// part of a collection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_identifier: Option<String>,
+    /// Identifier of the harvest job that produced this record.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harvest_job_id: Option<String>,
+    /// Identifier of the harvest source this record came from.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub harvest_source_id: Option<String>,
+    /// What the harvest did with this record, such as `update`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub action: Option<String>,
+    /// Outcome the harvester recorded for this record, such as
+    /// `success`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    /// Timestamp the harvest of this record began, ISO 8601 without
+    /// a zone offset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub date_created: Option<String>,
+    /// Timestamp the harvest of this record finished, ISO 8601
+    /// without a zone offset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub date_finished: Option<String>,
+    /// Hex digest of the upstream payload, used to detect whether it
+    /// changed since the last harvest.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_hash: Option<String>,
     /// Raw upstream payload (often a large JSON object or XML string).

--- a/data-gov-ckan/src/client.rs
+++ b/data-gov-ckan/src/client.rs
@@ -535,6 +535,20 @@ impl CkanClient {
     /// - Text search with wildcard: `q=climat*`
     /// - Phrase search: `q="air quality"`
     /// - Complex filter: `fq=organization:epa-gov AND res_format:CSV`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response. A
+    /// malformed `fq` lands here as a 400 from CKAN's Solr backend rather
+    /// than being rejected locally, because the syntax is passed through
+    /// unparsed.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the search envelope CKAN documents.
     pub async fn package_search(
         &self,
         q: Option<&str>,
@@ -656,11 +670,35 @@ impl CkanClient {
     /// - **Temporal**: Creation date, modification date, temporal coverage
     /// - **Spatial**: Geographic coverage and bounding boxes
     /// - **Custom Fields**: Agency-specific metadata extensions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn package_show(&self, id: &str) -> Result<models::Package, CkanError> {
         self.call_action("package_show", &[("id", id)]).await
     }
 
     /// List all organizations in the CKAN instance
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn organization_list(
         &self,
         sort: Option<&str>,
@@ -685,6 +723,18 @@ impl CkanClient {
     }
 
     /// List all groups in the CKAN instance
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn group_list(
         &self,
         sort: Option<&str>,
@@ -763,6 +813,18 @@ impl CkanClient {
     ///     Ok(())
     /// }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn dataset_autocomplete(
         &self,
         incomplete: Option<&str>,
@@ -782,6 +844,18 @@ impl CkanClient {
     }
 
     /// Get tag autocomplete suggestions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn tag_autocomplete(
         &self,
         incomplete: Option<&str>,
@@ -805,6 +879,18 @@ impl CkanClient {
     }
 
     /// Get user autocomplete suggestions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn user_autocomplete(
         &self,
         q: Option<&str>,
@@ -876,6 +962,18 @@ impl CkanClient {
     /// // Finding groups for dataset categorization
     /// let energy_groups = client.group_autocomplete(Some("energy"), Some(5)).await?;
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn group_autocomplete(
         &self,
         q: Option<&str>,
@@ -895,6 +993,18 @@ impl CkanClient {
     }
 
     /// Get organization autocomplete suggestions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn organization_autocomplete(
         &self,
         q: Option<&str>,
@@ -914,6 +1024,18 @@ impl CkanClient {
     }
 
     /// Get resource format autocomplete suggestions
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CkanError::RequestError`] if the request cannot be sent or
+    /// its body cannot be read: connection failure, timeout, DNS or TLS
+    /// error, or a dropped connection while reading the response.
+    ///
+    /// Returns [`CkanError::ApiError`] for any non-2xx response, carrying
+    /// CKAN's status and, where CKAN sent an error envelope, its message.
+    ///
+    /// Returns [`CkanError::ParseError`] if the body arrives whole but is
+    /// not the JSON shape this action returns.
     pub async fn resource_format_autocomplete(
         &self,
         incomplete: Option<&str>,

--- a/data-gov-mcp-server/src/main.rs
+++ b/data-gov-mcp-server/src/main.rs
@@ -1,3 +1,9 @@
+//! MCP server exposing the data.gov catalog to AI agents.
+
+// Every public item in this crate carries a doc comment, and that is
+// enforced rather than remembered (#59).
+#![deny(missing_docs)]
+
 // A TLS backend is not optional: every endpoint this crate talks to is HTTPS.
 // Without one, reqwest builds an HTTP-only connector, the crate compiles clean,
 // and the first request fails at connect with "invalid URL, scheme is not http".

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -47,6 +47,13 @@ struct DownloadJob<'a> {
 
 impl DataGovClient {
     /// Create a new DataGov client with default configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::ConfigError`] if the default configuration is
+    /// rejected, and [`DataGovError::HttpError`] if the underlying HTTP
+    /// client cannot be built - a missing or unusable TLS backend is the
+    /// realistic cause.
     pub fn new() -> Result<Self> {
         Self::with_config(DataGovConfig::new())
     }
@@ -133,6 +140,13 @@ impl DataGovClient {
     /// let next = client.search("climate", Some(20), page.after.as_deref(), None).await?;
     /// # Ok(()) }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::CatalogError`] if the Catalog API request
+    /// fails, returns a non-2xx status, or answers with a body that is not a
+    /// search envelope. `per_page` outside `1..=1000` is rejected before any
+    /// request is made.
     pub async fn search(
         &self,
         query: &str,
@@ -159,6 +173,14 @@ impl DataGovClient {
     /// Fetch a single dataset by its data.gov slug.
     ///
     /// Returns `Err(ResourceNotFound)` if no dataset matches.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::ResourceNotFound`] if no dataset carries that
+    /// slug, which is an answer rather than a fault. Returns
+    /// [`DataGovError::CatalogError`] if the lookup itself fails - network,
+    /// non-2xx status other than 404, or an unparseable body - or if `slug`
+    /// cannot be carried in a URL path segment.
     pub async fn get_dataset(&self, slug: &str) -> Result<SearchHit> {
         self.catalog
             .dataset_by_slug(slug)
@@ -175,6 +197,13 @@ impl DataGovClient {
     /// keeps a `Result<Dataset>` signature, the same shape [`Self::get_dataset`]
     /// uses for its own not-found case, rather than pushing an `Option` onto
     /// every caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::ResourceNotFound`] if the harvest record has
+    /// no populated transform, which is the common answer rather than a
+    /// fault. Returns [`DataGovError::CatalogError`] if the lookup itself
+    /// fails, or if `id` cannot be carried in a URL path segment.
     pub async fn get_dataset_by_harvest_record(&self, id: &str) -> Result<Dataset> {
         self.catalog
             .harvest_record_transformed(id)
@@ -190,6 +219,12 @@ impl DataGovClient {
     ///
     /// Implemented as a capped full-text search; the new API does not offer a
     /// dedicated dataset-autocomplete endpoint.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::CatalogError`] if the underlying search
+    /// fails; this shares [`Self::search`]'s failure modes exactly, since it
+    /// is implemented on top of it.
     pub async fn autocomplete_datasets(
         &self,
         partial: &str,
@@ -204,6 +239,12 @@ impl DataGovClient {
     }
 
     /// List the publisher slugs for government organizations, capped to `limit`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::CatalogError`] if the organizations request
+    /// fails, returns a non-2xx status, or answers with an unparseable body.
+    /// A negative `limit` is treated as no limit rather than an error.
     pub async fn list_organizations(&self, limit: Option<i32>) -> Result<Vec<String>> {
         let orgs = self.catalog.organizations().await?;
         let iter = orgs.organizations.into_iter().filter_map(|o| o.slug);
@@ -361,6 +402,16 @@ impl DataGovClient {
     ///   uses the configured base download directory.
     ///
     /// Returns the path where the file was written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::ValidationError`] if the distribution has no
+    /// download URL, if that URL is not a permitted target, or if the
+    /// derived filename would escape `output_dir`.
+    /// Returns [`DataGovError::HttpError`] if the transfer fails or the body
+    /// is shorter than its declared `Content-Length`, and
+    /// [`DataGovError::IoError`] if the file cannot be written or renamed
+    /// into place.
     pub async fn download_distribution(
         &self,
         distribution: &Distribution,
@@ -753,6 +804,13 @@ impl DataGovClient {
     /// Callers may run this concurrently against the same directory -- the
     /// MCP server does, on every download where `outputDir` is omitted --
     /// so the write-test probe must never share a name across calls (#112).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DataGovError::ConfigError`] if the path exists but is not a
+    /// directory, and [`DataGovError::IoError`] if the directory cannot be
+    /// created, or if the write probe cannot be written or removed - which
+    /// is what proves the directory is writable rather than merely present.
     pub async fn validate_download_dir(&self) -> Result<()> {
         let base_dir = self.config.get_base_download_dir();
 

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -1,3 +1,15 @@
+//! The high-level data.gov client.
+//!
+//! [`DataGovClient`] is the entry point for the crate: it searches the
+//! catalog, resolves datasets by slug or harvest record, and downloads
+//! distributions to disk. It wraps [`CatalogClient`] and adds what a consumer
+//! of the catalog needs but the transport should not carry - concurrency
+//! limits, filename derivation, path containment, and progress reporting
+//! through [`crate::ui::StatusReporter`].
+//!
+//! Construct one with [`DataGovClient::new`] for defaults, or
+//! [`DataGovClient::with_config`] to supply a [`DataGovConfig`].
+
 use futures::StreamExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/data-gov/src/error.rs
+++ b/data-gov/src/error.rs
@@ -1,3 +1,14 @@
+//! The crate's error type.
+//!
+//! Every fallible operation in this crate returns [`Result`], whose error is
+//! [`DataGovError`]. Errors from the layers underneath - the Catalog API,
+//! reqwest, the filesystem, URL parsing - arrive through `#[from]`
+//! conversions and keep their own detail rather than being flattened to a
+//! string.
+//!
+//! Use [`DataGovError::sanitized_message`] when an error crosses a trust
+//! boundary, since the message may name paths on the machine it came from.
+
 use data_gov_catalog::CatalogError;
 use thiserror::Error;
 
@@ -22,27 +33,47 @@ pub enum DataGovError {
 
     /// Resource not found.
     #[error("Resource not found: {message}")]
-    ResourceNotFound { message: String },
+    ResourceNotFound {
+        /// What was looked for and could not be found.
+        message: String,
+    },
 
     /// Download failed.
     #[error("Download failed: {message}")]
-    DownloadError { message: String },
+    DownloadError {
+        /// What went wrong during the transfer.
+        message: String,
+    },
 
     /// Invalid resource format.
     #[error("Invalid resource format: expected {expected}, got {actual}")]
-    InvalidFormat { expected: String, actual: String },
+    InvalidFormat {
+        /// Format the caller asked for.
+        expected: String,
+        /// Format the distribution actually advertises.
+        actual: String,
+    },
 
     /// Configuration error.
     #[error("Configuration error: {message}")]
-    ConfigError { message: String },
+    ConfigError {
+        /// Which setting is wrong, and what would be acceptable.
+        message: String,
+    },
 
     /// Validation error.
     #[error("Validation error: {message}")]
-    ValidationError { message: String },
+    ValidationError {
+        /// Which value failed the check, and why.
+        message: String,
+    },
 
     /// Generic error with custom message.
     #[error("{message}")]
-    Other { message: String },
+    Other {
+        /// The message, rendered verbatim by [`Display`](std::fmt::Display).
+        message: String,
+    },
 }
 
 impl DataGovError {

--- a/data-gov/src/error.rs
+++ b/data-gov/src/error.rs
@@ -81,21 +81,131 @@ impl DataGovError {
         }
     }
 
-    /// Sanitize error message for external consumption.
+    /// Render this error with filesystem paths replaced by `[path]`.
     ///
-    /// Removes filesystem paths and other potentially sensitive information.
+    /// Use it when an error crosses a trust boundary - a log shipped off
+    /// the machine, a response to a remote caller, a bug report. A path
+    /// discloses the account name and the directory layout of the machine
+    /// the tool ran on, neither of which the recipient needs.
+    ///
+    /// Every whitespace-separated token that looks like a path is
+    /// replaced, wherever it appears and however it is punctuated, so a
+    /// quoted or bracketed path is caught along with a bare one and the
+    /// punctuation around it is kept.
+    ///
+    /// URLs survive, because a public catalog URL is usually the one thing
+    /// that makes a failure actionable and it says nothing about the
+    /// machine. `file://` URLs do not survive: those are paths wearing a
+    /// scheme.
+    ///
+    /// Prose is left alone. `read/write` and `and/or` are not paths, so a
+    /// token needs more than one separator, or an anchor such as `/`,
+    /// `./`, `../`, `~/` or a drive letter, or a file extension after its
+    /// only separator, before it is treated as one.
+    ///
+    /// Runs of whitespace in the message collapse to single spaces.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use data_gov::DataGovError;
+    ///
+    /// let error = DataGovError::other("could not read /home/someone/q3 data/report.csv");
+    /// assert_eq!(error.sanitized_message(), "could not read [path] [path]");
+    ///
+    /// let error = DataGovError::other("GET https://catalog.data.gov/search failed");
+    /// assert_eq!(
+    ///     error.sanitized_message(),
+    ///     "GET https://catalog.data.gov/search failed"
+    /// );
+    /// ```
     pub fn sanitized_message(&self) -> String {
-        let msg = self.to_string();
-        msg.split_whitespace()
-            .map(|word| {
-                if word.starts_with('/') || word.contains(":\\") || word.starts_with("./") {
-                    "[path]"
-                } else {
-                    word
-                }
-            })
+        self.to_string()
+            .split_whitespace()
+            .map(redact_if_path)
             .collect::<Vec<_>>()
             .join(" ")
+    }
+}
+
+/// Characters that commonly open a quoted or bracketed path in an error
+/// message. A leading one of these hid the path from the original
+/// `starts_with('/')` test entirely.
+const LEADING_WRAPPERS: &[char] = &['"', '\'', '`', '(', '[', '{', '<'];
+
+/// Characters that commonly close a quoted or bracketed path, or end the
+/// sentence it sits in.
+const TRAILING_WRAPPERS: &[char] = &[
+    '"', '\'', '`', ')', ']', '}', '>', ',', ';', ':', '.', '!', '?',
+];
+
+/// Replace `token` with `[path]` if it is a path, keeping any punctuation
+/// that wraps it so the message still reads as a sentence.
+fn redact_if_path(token: &str) -> String {
+    let unwrapped = token.trim_start_matches(LEADING_WRAPPERS);
+    let core = unwrapped.trim_end_matches(TRAILING_WRAPPERS);
+
+    if !looks_like_a_path(core) {
+        return token.to_string();
+    }
+
+    let leading = &token[..token.len() - unwrapped.len()];
+    let trailing = &token[token.len() - (unwrapped.len() - core.len())..];
+    format!("{leading}[path]{trailing}")
+}
+
+/// Whether `token` is a filesystem path rather than prose or a URL.
+///
+/// The hard part is not recognising a path. It is not redacting ordinary
+/// English: `read/write` and `and/or` both carry a separator, and turning
+/// them into `[path]` would make the message useless while protecting
+/// nothing.
+fn looks_like_a_path(token: &str) -> bool {
+    if !token.contains('/') && !token.contains('\\') {
+        return false;
+    }
+
+    // A URL is not a filesystem path. `file://` is the exception: it
+    // carries one, and it is the shape that would otherwise slip through
+    // the URL exemption.
+    if let Some((scheme, _)) = token.split_once("://") {
+        return scheme.eq_ignore_ascii_case("file");
+    }
+
+    // Anchored forms settle it on shape alone, whatever follows.
+    const ANCHORS: &[&str] = &["/", "./", "../", "~/", ".\\", "..\\", "~\\", "\\\\"];
+    if ANCHORS.iter().any(|anchor| token.starts_with(anchor)) {
+        return true;
+    }
+
+    // A Windows drive letter: `C:\` or `C:/`.
+    let bytes = token.as_bytes();
+    if bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'/' || bytes[2] == b'\\')
+    {
+        return true;
+    }
+
+    // Unanchored, so only the shape of the remainder is left to go on.
+    // Two separators is a directory tree. One separator with a file
+    // extension after it is a file in a directory - and it is the tail of
+    // a path that contained a space, which is how the account name used to
+    // escape. One separator and no extension is prose.
+    let separators = token.chars().filter(|c| *c == '/' || *c == '\\').count();
+    if separators >= 2 {
+        return true;
+    }
+
+    let last_segment = token.rsplit(['/', '\\']).next().unwrap_or_default();
+    match last_segment.split_once('.') {
+        Some((stem, extension)) => {
+            !stem.is_empty()
+                && !extension.is_empty()
+                && extension.chars().all(|c| c.is_ascii_alphanumeric())
+        }
+        None => false,
     }
 }
 
@@ -105,6 +215,176 @@ pub type Result<T> = std::result::Result<T, DataGovError>;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- #59: `sanitized_message` claims to remove filesystem paths, and
+    // nothing held it to that claim. It had no test and no caller, so the
+    // documented property was a sentence rather than a behaviour. These
+    // pin it. ---
+
+    /// A stand-in for the thing that must never reach a log or a remote
+    /// consumer: the account name embedded in a home directory.
+    const USERNAME: &str = "someone";
+
+    fn sanitize(message: &str) -> String {
+        DataGovError::other(message).sanitized_message()
+    }
+
+    #[test]
+    fn an_absolute_path_is_replaced() {
+        let sanitized = sanitize("could not read /home/someone/data/report.csv today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    /// The original implementation split on whitespace and replaced only
+    /// the tokens that began with a separator. A path containing a space
+    /// therefore lost its first half and kept the rest, which is the half
+    /// that names the file.
+    #[test]
+    fn a_path_containing_spaces_leaks_no_component() {
+        let sanitized = sanitize("could not read /home/someone/my data/report.csv today");
+
+        assert!(
+            !sanitized.contains("report.csv"),
+            "the tail of a path with a space in it must not survive, got: {sanitized}"
+        );
+        assert!(
+            !sanitized.contains(USERNAME),
+            "the account name must not survive, got: {sanitized}"
+        );
+    }
+
+    /// `../secrets/key.txt` begins with neither `/` nor `./`, so the
+    /// original implementation passed it through untouched.
+    #[test]
+    fn a_parent_relative_path_is_replaced() {
+        let sanitized = sanitize("could not read ../secrets/key.txt today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    #[test]
+    fn a_home_relative_path_is_replaced() {
+        let sanitized = sanitize("could not read ~/secrets/key.txt today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    #[test]
+    fn a_bare_relative_path_is_replaced() {
+        let sanitized = sanitize("could not read data/private/notes.txt today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    #[test]
+    fn a_windows_path_is_replaced() {
+        let sanitized = sanitize("could not read C:\\Users\\someone\\report.csv today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    #[test]
+    fn a_unc_path_is_replaced() {
+        let sanitized = sanitize("could not read \\\\fileserver\\share\\report.csv today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    /// Error messages quote the path they are complaining about far more
+    /// often than they leave it bare, and a leading quote defeated the
+    /// original `starts_with('/')` test entirely.
+    #[test]
+    fn a_path_wrapped_in_punctuation_is_replaced_and_keeps_its_wrapper() {
+        for (message, expected) in [
+            (
+                "failed to open \"/home/someone/report.csv\" for writing",
+                "failed to open \"[path]\" for writing",
+            ),
+            (
+                "failed to open (/home/someone/report.csv) for writing",
+                "failed to open ([path]) for writing",
+            ),
+            (
+                "failed to open /home/someone/report.csv, giving up",
+                "failed to open [path], giving up",
+            ),
+            (
+                "failed to open '/home/someone/report.csv'.",
+                "failed to open '[path]'.",
+            ),
+        ] {
+            assert_eq!(sanitize(message), expected, "input was: {message}");
+        }
+    }
+
+    /// Sanitizing must not cost the reader the one thing that usually
+    /// makes a download failure actionable. A public catalog URL is not a
+    /// filesystem path and discloses nothing about the machine.
+    #[test]
+    fn a_url_survives_sanitization() {
+        let sanitized = sanitize("GET https://catalog.data.gov/api/dataset/foo failed");
+
+        assert_eq!(
+            sanitized,
+            "GET https://catalog.data.gov/api/dataset/foo failed"
+        );
+    }
+
+    /// The URL exemption must not become a way to smuggle a path past
+    /// the redaction. `file://` carries a filesystem path and is the one
+    /// scheme that has to lose.
+    #[test]
+    fn a_file_url_is_replaced_despite_the_url_exemption() {
+        let sanitized = sanitize("could not read file:///home/someone/report.csv today");
+
+        assert_eq!(sanitized, "could not read [path] today");
+    }
+
+    /// Redacting every token with a slash in it would turn ordinary
+    /// English into `[path]` and make the message useless.
+    #[test]
+    fn ordinary_prose_containing_a_slash_survives() {
+        let sanitized = sanitize("the file is open read/write and/or locked");
+
+        assert_eq!(sanitized, "the file is open read/write and/or locked");
+    }
+
+    #[test]
+    fn a_message_with_no_path_is_returned_unchanged() {
+        let sanitized = sanitize("Validation failed: per_page must be between 1 and 1000");
+
+        assert_eq!(
+            sanitized,
+            "Validation failed: per_page must be between 1 and 1000"
+        );
+    }
+
+    /// The property the doc comment actually promises, checked across
+    /// every shape above at once rather than one example at a time.
+    #[test]
+    fn no_path_shape_lets_the_account_name_through() {
+        let shapes = [
+            "/home/someone/report.csv",
+            "/home/someone/my data/report.csv",
+            "../../home/someone/report.csv",
+            "~/someone/report.csv",
+            "home/someone/report.csv",
+            "C:\\Users\\someone\\report.csv",
+            "\\\\fileserver\\someone\\report.csv",
+            "\"/home/someone/report.csv\"",
+            "(/home/someone/report.csv)",
+            "/home/someone/report.csv.",
+        ];
+
+        for shape in shapes {
+            let sanitized = sanitize(&format!("could not read {shape} today"));
+            assert!(
+                !sanitized.contains(USERNAME),
+                "{shape:?} leaked the account name as: {sanitized}"
+            );
+        }
+    }
 
     /// #77: `validation_error` had no test that called it directly -- every
     /// exercise of it went through `data_gov::util`'s checks, which

--- a/data-gov/src/lib.rs
+++ b/data-gov/src/lib.rs
@@ -6,6 +6,9 @@
 //! dataset inspection, and downloading published distributions. The main entry
 //! point is [`DataGovClient`], which requires a Tokio runtime.
 
+// Every public item in this crate carries a doc comment, and that is
+// enforced rather than remembered (#59).
+#![deny(missing_docs)]
 // A TLS backend is not optional: every endpoint this crate talks to is HTTPS.
 // Without one, reqwest builds an HTTP-only connector, the crate compiles clean,
 // and the first request fails at connect with "invalid URL, scheme is not http".
@@ -24,13 +27,26 @@ compile_error!(
 pub const DATA_GOV_BASE_URL: &str = "https://catalog.data.gov";
 
 // Re-export the catalog crate for direct access
+/// The lower-level Catalog API client this crate is built on.
+///
+/// Re-exported so a consumer can reach the raw request types -
+/// [`SearchParams`](catalog::SearchParams) and the DCAT-US 3 models - without
+/// adding `data-gov-catalog` to their manifest and risking a version skew
+/// between the two.
 pub use data_gov_catalog as catalog;
 
 // Public modules
 pub mod client;
 pub mod config;
 pub mod error;
+/// Progress reporting for long-running downloads.
 pub mod ui;
+/// Path and filename handling for downloaded files.
+///
+/// The functions here exist because a filename derived from remote metadata
+/// is untrusted input: a distribution title is chosen by the publisher, not
+/// by this crate, and it reaches the filesystem. They sanitize a single path
+/// component and keep a joined path inside the directory it was meant for.
 pub mod util;
 
 // Re-export main types for convenience

--- a/data-gov/src/ui/mod.rs
+++ b/data-gov/src/ui/mod.rs
@@ -1,48 +1,142 @@
+//! Progress reporting for long-running downloads.
+//!
+//! Downloads are the one operation in this crate slow enough that a caller
+//! needs to show progress, and the crate cannot know how: a terminal wants a
+//! progress bar, an MCP server wants structured events, a test wants a
+//! recording. So the client emits events and a consumer decides what they
+//! mean.
+//!
+//! Implement [`StatusReporter`] and hand it to
+//! [`DataGovConfig::with_status_reporter`](crate::DataGovConfig::with_status_reporter).
+//! Every method has a default that does nothing, so an implementation only
+//! overrides the events it cares about, and a new event added here does not
+//! break an existing implementation.
+//!
+//! With no reporter configured, downloads run silently.
+//!
+//! The events fire in order: [`DownloadBatch`] once for a batch, then
+//! [`DownloadStarted`], zero or more [`DownloadProgress`], and exactly one
+//! of [`DownloadFinished`] or [`DownloadFailed`] per file.
+//!
+//! # Examples
+//!
+//! ```
+//! use data_gov::ui::{DownloadFinished, StatusReporter};
+//!
+//! struct CountFinished(std::sync::atomic::AtomicUsize);
+//!
+//! impl StatusReporter for CountFinished {
+//!     fn on_download_finished(&self, _event: &DownloadFinished) {
+//!         self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+//!     }
+//! }
+//! ```
+
 use std::path::PathBuf;
 
+/// A batch of downloads is about to start.
+///
+/// Emitted once per call that downloads more than one file, before any
+/// [`DownloadStarted`].
 #[derive(Debug, Clone)]
 pub struct DownloadBatch {
+    /// How many files the batch will attempt.
     pub resource_count: usize,
+    /// Title of the dataset the batch belongs to, where one is known.
     pub dataset_name: Option<String>,
 }
 
+/// One file's transfer has begun.
 #[derive(Debug, Clone)]
 pub struct DownloadStarted {
+    /// Title of the distribution being fetched, where the metadata carries
+    /// one.
     pub resource_name: Option<String>,
+    /// Title of the dataset it belongs to, where one is known.
     pub dataset_name: Option<String>,
+    /// URL being fetched.
     pub url: String,
+    /// Final path the file will occupy once the transfer completes.
+    ///
+    /// The transfer writes to a temporary path and renames onto this one at
+    /// the end, so this path holds either nothing or a whole file - never a
+    /// partial download.
     pub output_path: PathBuf,
+    /// Size the server declared, where it sent a `Content-Length`.
+    ///
+    /// `None` means the size is unknown, not that the file is empty, so a
+    /// reporter should show an indeterminate indicator rather than a bar.
     pub total_bytes: Option<u64>,
 }
 
+/// A file's transfer has advanced.
+///
+/// Emitted repeatedly as bytes arrive. A reporter that does per-event work
+/// should expect this to fire often.
 #[derive(Debug, Clone)]
 pub struct DownloadProgress {
+    /// Title of the distribution being fetched, where the metadata carries
+    /// one.
     pub resource_name: Option<String>,
+    /// Title of the dataset it belongs to, where one is known.
     pub dataset_name: Option<String>,
+    /// Final path the file will occupy, matching the
+    /// [`DownloadStarted::output_path`] this progress belongs to.
     pub output_path: PathBuf,
+    /// Bytes received so far.
     pub downloaded_bytes: u64,
+    /// Size the server declared, or `None` where it sent no
+    /// `Content-Length`.
     pub total_bytes: Option<u64>,
 }
 
+/// A file arrived whole and is now at its final path.
 #[derive(Debug, Clone)]
 pub struct DownloadFinished {
+    /// Title of the distribution that was fetched, where the metadata
+    /// carries one.
     pub resource_name: Option<String>,
+    /// Title of the dataset it belongs to, where one is known.
     pub dataset_name: Option<String>,
+    /// Path the completed file now occupies.
     pub output_path: PathBuf,
 }
 
+/// A file's transfer did not complete.
+///
+/// Any partial data has already been discarded, so nothing is left at
+/// [`Self::output_path`] from this attempt.
 #[derive(Debug, Clone)]
 pub struct DownloadFailed {
+    /// Title of the distribution that was being fetched, where the metadata
+    /// carries one.
     pub resource_name: Option<String>,
+    /// Title of the dataset it belongs to, where one is known.
     pub dataset_name: Option<String>,
+    /// Path the file would have occupied, where the failure happened late
+    /// enough for one to have been chosen.
     pub output_path: Option<PathBuf>,
+    /// What went wrong, rendered for a person to read.
     pub error: String,
 }
 
+/// Receives download progress events.
+///
+/// Every method does nothing by default, so implement only the events you
+/// need. Implementations are called from async tasks and may be called
+/// concurrently for different files, which is why `Send + Sync` is required.
+///
+/// A method that blocks stalls the transfer that called it, so do the
+/// minimum here and send anything expensive elsewhere.
 pub trait StatusReporter: Send + Sync {
+    /// A batch of downloads is about to start.
     fn on_download_batch(&self, _event: &DownloadBatch) {}
+    /// One file's transfer has begun.
     fn on_download_started(&self, _event: &DownloadStarted) {}
+    /// A file's transfer has advanced. Fires repeatedly.
     fn on_download_progress(&self, _event: &DownloadProgress) {}
+    /// A file arrived whole and is at its final path.
     fn on_download_finished(&self, _event: &DownloadFinished) {}
+    /// A file's transfer did not complete.
     fn on_download_failed(&self, _event: &DownloadFailed) {}
 }


### PR DESCRIPTION
Addresses all three parts of #59. Part 1 is scoped deliberately; see below.

## 1. `sanitized_message` leaked the paths it promised to remove

`DataGovError::sanitized_message` documented itself as stripping filesystem
paths from an error before it crosses a trust boundary. It had **no test and
no caller**, so the property was a sentence rather than a behaviour - and the
behaviour did not match. It split on whitespace and replaced only tokens
beginning with `/` or `./`.

Everything else went through untouched:

| Input | Old output |
|---|---|
| `/home/someone/my data/report.csv` | `[path] data/report.csv` |
| `../secrets/key.txt` | unchanged |
| `~/secrets/key.txt` | unchanged |
| `"/home/someone/report.csv"` | unchanged - the token began with a quote |

The last row is the one that mattered most: error messages quote the path
they are complaining about far more often than they leave it bare.

Redaction is now decided per token after stripping wrapping punctuation,
which is put back around the `[path]` marker so the message still reads as a
sentence. A token is a path if it is anchored (`/`, `./`, `../`, `~/`, a
drive letter, a UNC prefix), or carries two separators, or has a file
extension after its only separator - the last of which catches the tail of a
path that contained a space.

Two things deliberately survive, because redacting them protects nothing and
costs the reader the message:

- **URLs.** A public catalog URL is usually the only actionable part of a
  download failure and says nothing about the machine. `file://` is the
  exception and is redacted, being a path wearing a scheme.
- **Prose.** `read/write` and `and/or` carry a separator and are not paths,
  which is why one separator alone does not trigger redaction.

15 tests, written first. **7 failed against the old implementation**, naming
each leak; the 6 that passed pin the cases it already handled so they cannot
regress. One asserts the account name survives no path shape at all.

## 2. `# Errors` sections

`clippy::missing_errors_doc` and `clippy::missing_panics_doc` are denied
workspace-wide, and the 24 public `Result`-returning functions that had none
now have one. They name the variants that call path can actually produce
rather than repeating one paragraph - the three catalog endpoints that encode
a path segment can fail before any request is made, and say so. No
`# Panics` gaps existed.

## 3. `missing_docs` - scoped, and here is why

Enabled and cleared for the three crates data.gov actually runs on:

| Crate | `#![deny(missing_docs)]` | Items documented |
|---|---|---|
| `data-gov-catalog` | yes | 60 DCAT-US 3 model fields |
| `data-gov` | yes | 40 - the whole `ui` module, error fields, two module docs |
| `data-gov-mcp-server` | yes | 0 - already clean |
| `data-gov-ckan` | **no** | **170 outstanding, tracked as #118** |

`data-gov-ckan` is the largest share by far and is the crate data.gov no
longer uses, so holding a release for it was the wrong trade. #118 carries it
with the context a fresh session needs.

The `ui` module is the part worth reading: it is the download
progress-reporting port and had no documentation at all, so a consumer
implementing `StatusReporter` had to read the client's source to learn the
event order, that every method has a do-nothing default, that
`total_bytes: None` means unknown rather than empty, and that a blocking
implementation stalls the transfer that called it.

Catalog field docs were written from the captured fixtures, not from the
field names. That is what makes `bureau_code` and `program_code` explicable:
they are untyped because publishers send both a bare string and an array, and
a strict type would fail the whole record over one publisher's choice.

## Verification and limits

- `just check` green: 601 tests.
- **Each `deny` was proved live** by adding an undocumented `pub` item and
  watching the crate fail, then removing it. A configured-but-inert lint
  would look exactly like this PR.
- **Counts per crate are misleading while a crate below fails to compile.**
  Clippy stops at the first failing crate and never checks its dependents, so
  `data-gov` and `data-gov-mcp-server` both reported `data-gov-catalog`'s 60
  as their own until that crate was cleared. Each crate was cleared and
  re-measured in dependency order. The 232 first reported was a floor, not a
  total.
- The `sanitizer` tests originally used a realistic placeholder username,
  which the repo's own `check-home-paths` guard correctly rejected. Switched
  to an allowlisted placeholder.
- Not audited: whether any *other* stated property in the workspace lacks an
  enforcer. `sanitized_message` was found because #59 named it.

Refs #59, #118