### PR TITLE
feat(mcp-server): resolve configuration through the CLI's chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   goes to stderr via `tracing` at startup.
 
 ### Changed
+- **The MCP server now resolves configuration through the same chain as the
+  CLI** (#116). It previously read `DATA_GOV_BASE_URL` and
+  `DATA_GOV_USER_AGENT` by hand and built its configuration programmatically,
+  so `config.toml` (added in this release) had no effect on the agent-facing
+  front door, and `DATA_GOV_DOWNLOAD_DIR`,
+  `DATA_GOV_MAX_CONCURRENT_DOWNLOADS` and `DATA_GOV_DOWNLOAD_TIMEOUT_SECS`
+  were ignored outright. All five settings now resolve as
+  `environment variable > config file > built-in default` - the CLI's chain
+  without the flag layer the server does not have.
+
+  **What changes for you:** if you set any of those three environment
+  variables when launching the server, they now take effect where before they
+  did nothing. If you keep a `config.toml`, the server now honours it. The
+  environment still beats the file, so a host that sets variables is
+  unaffected. `DATA_GOV_BASE_URL` and `DATA_GOV_USER_AGENT` behave exactly as
+  before.
+
+  A `config.toml` that cannot be parsed, or a value that cannot work, now
+  stops the server at startup naming the setting, rather than being ignored.
+  Warnings go to stderr, never stdout, which carries the JSON-RPC stream.
 - **MCP responses may arrive out of order; correlate by `id`** (#65). The run
   loop awaited each handler before reading the next line, so a
   `downloadResources` call holding that await for minutes queued every later

--- a/data-gov-mcp-server/README.md
+++ b/data-gov-mcp-server/README.md
@@ -157,14 +157,32 @@ This will configure VSCode to launch the MCP server and connect to it for tool-b
 
 ## Configuration
 
-Environment variables:
+**The server and the CLI resolve configuration by the same rules.** Both read
+`<config>/data-gov/config.toml` and the same environment variables, through one
+chain. The settings table, the file's location on each platform, and the
+per-setting details live in one place: the
+[configuration section of the `data-gov` README](../data-gov/README.md#the-config-file).
 
-- `DATA_GOV_BASE_URL` – Override the default Catalog API base URL
-  (defaults to `https://catalog.data.gov`).
-- `DATA_GOV_USER_AGENT` – Custom user agent applied to the client.
+The server takes no command-line flags, so the chain it sees is:
 
-These settings are optional; when omitted the defaults from the underlying
-library are used. The Catalog API does not require an API key.
+**environment variable > config file > built-in default**
+
+The environment wins over the file on purpose. An MCP server is launched by a
+host application with an environment of the host's choosing, and an operator
+who configures the host stays in charge of it - the file supplies what the host
+did not.
+
+All five settings apply: `download_dir`, `base_url`, `max_concurrent_downloads`,
+`download_timeout_secs`, and `user_agent`. `download_dir` is the default target
+for `data_gov_download_resources` when a call omits `outputDir`.
+
+Everything is optional; with nothing set anywhere the server runs on the
+built-in defaults. The Catalog API does not require an API key.
+
+A `config.toml` that cannot be read or parsed, or a value that cannot work,
+stops the server at startup with a message naming the setting - it does not
+run on settings the operator did not choose. Warnings go to **stderr**, never
+stdout, because stdout carries the JSON-RPC stream.
 
 ## Cargo features
 

--- a/data-gov-mcp-server/src/config_tests.rs
+++ b/data-gov-mcp-server/src/config_tests.rs
@@ -1,0 +1,289 @@
+//! #116: the MCP server resolves configuration through the same chain the
+//! CLI uses.
+//!
+//! #86 gave `data-gov` a configuration file and one precedence chain - flag,
+//! then environment, then `config.toml`, then the built-in default. The MCP
+//! server did not use it: it read two environment variables by hand and built
+//! `DataGovConfig` programmatically, so a setting a user persisted in
+//! `config.toml` silently had no effect on the agent-facing front door, and
+//! three environment variables the CLI honours were ignored outright.
+//!
+//! AGENTS.md states the library, the CLI, and the MCP server are three faces
+//! over one client, and that a capability one has and another lacks is a
+//! layering defect rather than a missing convenience. These tests hold the two
+//! front doors to the same rules.
+//!
+//! The server has no command-line flags, so the chain it sees is environment,
+//! then file, then default. Every test drives an explicit environment and an
+//! explicit parsed file rather than the real process and the real filesystem,
+//! so nothing here depends on the machine it runs on or races another test
+//! over a process-global variable.
+
+use std::path::PathBuf;
+
+use data_gov::config::{ConfigEnvironment, ConfigFile, ConfigResolver};
+use data_gov::{DataGovClient, DataGovError, OperatingMode};
+use serde_json::json;
+use wiremock::matchers::{method as wm_method, path as wm_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use crate::server::{DEFAULT_REQUEST_TIMEOUT, DataGovMcpServer};
+
+/// A resolver with no flags, the given environment pairs, and the given
+/// `config.toml` text - never the real process or the real filesystem.
+fn resolver(env_pairs: &[(&str, &str)], config_toml: Option<&str>) -> ConfigResolver {
+    let mut resolver = ConfigResolver::new()
+        .with_environment(ConfigEnvironment::from_pairs(env_pairs.iter().copied()))
+        .with_mode(OperatingMode::CommandLine);
+    if let Some(text) = config_toml {
+        let parsed = ConfigFile::parse(text, "config.toml").expect("the test config.toml parses");
+        resolver = resolver.with_config_file(parsed);
+    }
+    resolver
+}
+
+#[test]
+fn a_config_file_download_dir_reaches_the_mcp_server() {
+    let server =
+        DataGovMcpServer::from_resolver(resolver(&[], Some("download_dir = \"/srv/datasets\"\n")))
+            .expect("the server builds");
+
+    assert_eq!(
+        server.download_dir_for_test(),
+        PathBuf::from("/srv/datasets"),
+        "a download directory persisted in config.toml must reach the MCP \
+         server, not just the CLI (#116)"
+    );
+}
+
+#[test]
+fn a_config_file_base_url_reaches_the_mcp_server() {
+    let server = DataGovMcpServer::from_resolver(resolver(
+        &[],
+        Some("base_url = \"https://catalog.example.gov\"\n"),
+    ))
+    .expect("the server builds");
+
+    assert_eq!(
+        server.portal_base_url_for_test(),
+        "https://catalog.example.gov",
+        "config.toml must be able to redirect the catalog the server talks to"
+    );
+}
+
+/// The host launching an MCP server owns its environment, and the precedence
+/// chain already says environment beats file. Reading the file must not
+/// quietly override what the host set.
+#[test]
+fn the_host_environment_beats_the_config_file() {
+    let server = DataGovMcpServer::from_resolver(resolver(
+        &[("DATA_GOV_DOWNLOAD_DIR", "/run/host-chosen")],
+        Some("download_dir = \"/srv/datasets\"\n"),
+    ))
+    .expect("the server builds");
+
+    assert_eq!(
+        server.download_dir_for_test(),
+        PathBuf::from("/run/host-chosen"),
+        "the environment the host supplied must win over config.toml"
+    );
+}
+
+/// `DATA_GOV_BASE_URL` and `DATA_GOV_USER_AGENT` were the only two settings
+/// the server read before this change. They must keep working exactly as they
+/// did, or the change breaks every existing deployment.
+#[test]
+fn the_two_environment_variables_the_server_already_read_still_work() {
+    let server = DataGovMcpServer::from_resolver(resolver(
+        &[
+            ("DATA_GOV_BASE_URL", "https://catalog.example.gov"),
+            ("DATA_GOV_USER_AGENT", "probe/1.0"),
+        ],
+        None,
+    ))
+    .expect("the server builds");
+
+    assert_eq!(
+        server.portal_base_url_for_test(),
+        "https://catalog.example.gov"
+    );
+    assert_eq!(server.user_agent_for_test().as_deref(), Some("probe/1.0"));
+}
+
+/// Three environment variables the CLI honours were ignored by the server
+/// outright - the exact shape of #53, where a setting is accepted in one
+/// place and silently dropped in another.
+#[test]
+fn the_environment_variables_the_server_used_to_ignore_now_reach_it() {
+    let server = DataGovMcpServer::from_resolver(resolver(
+        &[
+            ("DATA_GOV_DOWNLOAD_DIR", "/run/downloads"),
+            ("DATA_GOV_MAX_CONCURRENT_DOWNLOADS", "7"),
+            ("DATA_GOV_DOWNLOAD_TIMEOUT_SECS", "42"),
+        ],
+        None,
+    ))
+    .expect("the server builds");
+
+    assert_eq!(
+        server.download_dir_for_test(),
+        PathBuf::from("/run/downloads")
+    );
+    assert_eq!(server.max_concurrent_downloads_for_test(), 7);
+    assert_eq!(server.download_timeout_secs_for_test(), 42);
+}
+
+/// With nothing set anywhere, the server must still start on the built-in
+/// defaults rather than refusing.
+#[test]
+fn an_empty_environment_and_no_file_still_builds_a_server() {
+    let server = DataGovMcpServer::from_resolver(resolver(&[], None)).expect("the server builds");
+
+    assert_eq!(
+        server.portal_base_url_for_test(),
+        "https://catalog.data.gov"
+    );
+}
+
+/// A value that cannot work must stop the server at startup, naming the
+/// setting, rather than producing a client that fails on first use.
+#[test]
+fn a_value_that_cannot_work_fails_startup_and_names_the_setting() {
+    let outcome = DataGovMcpServer::from_resolver(resolver(
+        &[("DATA_GOV_MAX_CONCURRENT_DOWNLOADS", "0")],
+        None,
+    ));
+
+    let message = match outcome {
+        Err(err) => err.to_string(),
+        Ok(_) => panic!("a zero concurrency limit must not build a server"),
+    };
+    assert!(
+        message.contains("max_concurrent_downloads"),
+        "the failure must name the setting that is wrong, got: {message}"
+    );
+}
+
+/// A broken `config.toml` is a fault the operator has to see, not something
+/// to shrug off - the CLI already refuses to start on one.
+#[test]
+fn a_malformed_config_file_is_an_error_rather_than_being_ignored() {
+    let outcome = ConfigFile::parse("download_dir = \n", "config.toml");
+
+    assert!(
+        matches!(outcome, Err(DataGovError::ConfigError { .. })),
+        "a malformed config.toml must be a ConfigError, so the server can \
+         refuse to start rather than run on settings the operator did not choose"
+    );
+}
+
+/// A scratch directory unique to this process and thread.
+fn scratch_dir(name: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "data-gov-mcp-config-{name}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
+/// #116's acceptance criterion: a `config.toml` setting must reach an MCP
+/// **tool call**, not merely the server's configuration struct.
+///
+/// This drives the real `data_gov.downloadResources` handler with **no**
+/// `outputDir` argument, so the only thing that can decide where the file
+/// lands is the resolved default - which here comes from `config.toml` and
+/// nowhere else.
+///
+/// One thing is set outside the chain, deliberately: downloads refuse
+/// loopback addresses by default, and the mock catalog listens on one. That
+/// opt-in is a property of the test harness rather than of the precedence
+/// chain, and it is the same opt-in `test_support::test_server` takes.
+#[tokio::test]
+async fn a_config_file_download_dir_decides_where_a_tool_call_writes() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/api/dataset/config-probe"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "slug": "config-probe",
+                "title": "Config Probe",
+                "dcat": {
+                    "@type": "dcat:Dataset",
+                    "title": "Config Probe",
+                    "distribution": [{
+                        "@type": "dcat:Distribution",
+                        "title": "readings",
+                        "downloadURL": format!("{}/readings.csv", mock.uri()),
+                        "mediaType": "text/csv"
+                    }]
+                }
+            }],
+            "sort": "relevance"
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/readings.csv"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("a,b\n1,2\n"))
+        .mount(&mock)
+        .await;
+
+    let chosen_dir = scratch_dir("download-dir");
+    let config_toml = format!(
+        "download_dir = {:?}\nbase_url = {:?}\n",
+        chosen_dir.to_string_lossy(),
+        mock.uri()
+    );
+
+    let resolved = resolver(&[], Some(&config_toml))
+        .resolve()
+        .expect("the config.toml resolves");
+    let config = resolved.into_config().with_private_network_downloads(true);
+    let server = DataGovMcpServer {
+        data_gov: DataGovClient::with_config(config).expect("build the client"),
+        portal_base_url: mock.uri(),
+        request_timeout: DEFAULT_REQUEST_TIMEOUT,
+        test_gate: None,
+    };
+
+    let value = server
+        .dispatch(
+            "tools/call",
+            Some(json!({
+                "name": "data_gov_download_resources",
+                "arguments": {
+                    "datasetId": "config-probe",
+                    "datasetSubdirectory": false
+                }
+            })),
+        )
+        .await
+        .expect("the download dispatches");
+
+    let summary = &value["structuredContent"];
+    let reported_dir = summary["downloadDirectory"].as_str().unwrap_or_default();
+    // Assert on the directory the chain chose, not on a filename: the name is
+    // derived from the distribution title elsewhere, and pinning it here would
+    // make this test fail for a reason that has nothing to do with #116.
+    let written_path = summary["downloads"][0]["path"]
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+    let landed_inside = PathBuf::from(&written_path).starts_with(&chosen_dir)
+        && PathBuf::from(&written_path).exists();
+    let _ = std::fs::remove_dir_all(&chosen_dir);
+
+    assert_eq!(
+        reported_dir,
+        chosen_dir.to_string_lossy(),
+        "with no outputDir argument, the directory config.toml named must be \
+         the one the tool call used, which is the whole point of #116: {value}"
+    );
+    assert!(
+        landed_inside,
+        "the file must actually exist under the config.toml directory, not \
+         merely be reported there. Reported path: {written_path}"
+    );
+}

--- a/data-gov-mcp-server/src/main.rs
+++ b/data-gov-mcp-server/src/main.rs
@@ -17,6 +17,8 @@ mod types;
 #[cfg(test)]
 mod concurrency_tests;
 #[cfg(test)]
+mod config_tests;
+#[cfg(test)]
 mod dispatch_tests;
 #[cfg(test)]
 mod protocol_tests;

--- a/data-gov-mcp-server/src/server.rs
+++ b/data-gov-mcp-server/src/server.rs
@@ -1,10 +1,10 @@
 //! MCP server entry point — struct definition, construction, and run loop.
 
-use data_gov::{DataGovClient, DataGovConfig, OperatingMode};
+use data_gov::config::ConfigResolver;
+use data_gov::{DataGovClient, OperatingMode};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{
@@ -156,18 +156,48 @@ impl DataGovMcpServer {
         server.run().await
     }
 
-    /// Build a new server from environment variables.
+    /// Build a new server from the process environment and `config.toml`.
+    ///
+    /// # Errors
+    ///
+    /// [`ServerError::DataGov`] if `config.toml` exists but cannot be read or
+    /// parsed, or if any layer supplied a value that cannot work. Both fail
+    /// startup rather than producing a client that misbehaves later.
     fn new() -> Result<Self, ServerError> {
-        let base_url = env::var("DATA_GOV_BASE_URL").ok();
-        let user_agent = env::var("DATA_GOV_USER_AGENT").ok();
+        Self::from_resolver(ConfigResolver::from_process()?.with_mode(OperatingMode::CommandLine))
+    }
 
-        let mut config = DataGovConfig::new().with_mode(OperatingMode::CommandLine);
-        if let Some(url) = base_url {
-            config = config.with_base_url(url);
+    /// Build a server from an already-assembled configuration resolver.
+    ///
+    /// The server has no command-line flags, so the chain it sees is
+    /// environment, then `config.toml`, then the built-in default - the same
+    /// chain the CLI resolves, minus the layer that does not exist here
+    /// (#116). The host's environment therefore still wins over anything the
+    /// user persisted in a file, which is what keeps an operator who
+    /// configures the host in charge of it.
+    ///
+    /// Taking the resolver rather than reading the process is what makes
+    /// configuration testable: a test supplies explicit environment pairs and
+    /// an explicit parsed file, and touches neither the real environment nor
+    /// the filesystem.
+    ///
+    /// # Errors
+    ///
+    /// [`ServerError::DataGov`] if resolution fails - a non-numeric count, a
+    /// zero concurrency limit or timeout, an empty user agent or download
+    /// directory, or a base URL that is not `http` or `https`. The message
+    /// names the setting and the layer the value came from.
+    pub(crate) fn from_resolver(resolver: ConfigResolver) -> Result<Self, ServerError> {
+        let resolved = resolver.resolve()?;
+
+        // stdout is the JSON-RPC channel and nothing but framed responses may
+        // appear on it, so a warning goes to stderr. The host shows stderr in
+        // its logs; a line on stdout would corrupt the protocol stream.
+        for warning in resolved.warnings() {
+            eprintln!("data-gov-mcp-server: warning: {warning}");
         }
-        if let Some(ua) = user_agent {
-            config = config.with_user_agent(ua);
-        }
+
+        let config = resolved.into_config();
         let portal_base_url = config.catalog_config.base_path.clone();
         let data_gov = DataGovClient::with_config(config)?;
 
@@ -178,6 +208,36 @@ impl DataGovMcpServer {
             #[cfg(test)]
             test_gate: None,
         })
+    }
+
+    /// The resolved download directory. Test-only accessor for #116.
+    #[cfg(test)]
+    pub(crate) fn download_dir_for_test(&self) -> std::path::PathBuf {
+        self.data_gov.config().get_base_download_dir()
+    }
+
+    /// The resolved catalog base URL. Test-only accessor for #116.
+    #[cfg(test)]
+    pub(crate) fn portal_base_url_for_test(&self) -> &str {
+        &self.portal_base_url
+    }
+
+    /// The resolved user agent. Test-only accessor for #116.
+    #[cfg(test)]
+    pub(crate) fn user_agent_for_test(&self) -> Option<String> {
+        self.data_gov.config().catalog_config.user_agent.clone()
+    }
+
+    /// The resolved download concurrency limit. Test-only accessor for #116.
+    #[cfg(test)]
+    pub(crate) fn max_concurrent_downloads_for_test(&self) -> usize {
+        self.data_gov.config().max_concurrent_downloads
+    }
+
+    /// The resolved per-download timeout. Test-only accessor for #116.
+    #[cfg(test)]
+    pub(crate) fn download_timeout_secs_for_test(&self) -> u64 {
+        self.data_gov.config().download_timeout_secs
     }
 
     /// Main run loop: read JSON-RPC lines from stdin, dispatch, write responses.

--- a/data-gov/README.md
+++ b/data-gov/README.md
@@ -320,6 +320,13 @@ Every setting resolves through one chain, highest first:
 An empty environment variable (`DATA_GOV_DOWNLOAD_DIR=`) reads as unset, not as
 an empty value.
 
+**The MCP server resolves the same way** (#116). It reads the same file and the
+same variables through the same chain, minus the flag layer it does not have,
+so `environment variable > config file > built-in default`. A setting persisted
+here therefore reaches an agent's tool call as well as the terminal. The
+environment still wins over the file, which keeps an operator who configures
+the MCP host in charge of it.
+
 A few details worth knowing:
 
 - `base_url` and `user_agent` are trimmed of surrounding whitespace — a trailing


### PR DESCRIPTION
Settles and implements #116. The decision and its reasoning are recorded on
the issue.

## The problem

#86 gave `data-gov` a configuration file and one precedence chain. The MCP
server did not use it - it read two environment variables by hand and built
`DataGovConfig` programmatically, as it always had.

Nothing was broken, but the two front doors resolved configuration by
different rules. A user who set `download_dir` in `config.toml`, watched the
CLI honour it, and then found their agent downloading somewhere else had no
way to discover why. Three further variables the CLI honours were ignored
outright - the same shape as #53, where a setting is accepted in one place and
silently dropped in another.

| Setting | Before | After |
|---|---|---|
| `base_url` | env only | env > file > default |
| `user_agent` | env only | env > file > default |
| `download_dir` | **ignored** | env > file > default |
| `max_concurrent_downloads` | **ignored** | env > file > default |
| `download_timeout_secs` | **ignored** | env > file > default |

## The decision

The server reads the file, and the host's environment wins - the middle option
of the three, and what the precedence chain already expresses. AGENTS.md says
the three front doors are faces over one client and a capability gap between
them is a layering defect; against that, an MCP server is launched by a host
with an environment of the host's choosing, so an operator who configures the
host must stay in charge of it. Environment-over-file satisfies both.

**The change is strictly additive.** A host that sets environment variables
sees no difference. `DATA_GOV_BASE_URL` and `DATA_GOV_USER_AGENT` behave
exactly as before, and there is a test that says so.

## Design note

`from_resolver` takes an assembled `ConfigResolver` rather than reading the
process. That is what makes configuration testable at all: the tests supply
explicit environment pairs and an explicit parsed file and touch neither the
real environment nor the filesystem, so none of them race another test over a
process-global variable. `new()` is the thin wrapper that builds one from the
process.

Warnings go to **stderr**. stdout carries the JSON-RPC stream and a line on it
would corrupt the protocol.

## Tests

Nine, all network-free except the one that uses a loopback wiremock.

Eight cover the chain: file reaches the server, environment beats file, the
two variables that already worked still work identically, the three that were
ignored now arrive, an empty environment with no file still starts, a value
that cannot work stops startup naming the setting, and a malformed file is an
error rather than being shrugged off.

The ninth is #116's actual acceptance criterion, and it is the one worth
reading: `a_config_file_download_dir_decides_where_a_tool_call_writes` drives
the real `data_gov.downloadResources` handler with **no** `outputDir`
argument, so the only thing that can decide where the file lands is the
resolved default. It asserts the directory the chain chose and that the file
exists under it.

That test initially failed on a wrong assertion of mine, not on the code: I
guessed the filename would be `readings.csv`, but the crate derives it from
the distribution title. It now asserts the invariant - the reported directory
and the file's actual location - rather than a filename derivation that
belongs to a different test.

## Limits of what was checked

- One setting is applied outside the chain in the end-to-end test: downloads
  refuse loopback addresses by default and the mock catalog listens on one.
  That opt-in is a property of the test harness, not of the precedence chain,
  and it is the same one `test_support::test_server` takes. Called out in a
  comment on the test.
- `just check` green: 595 tests on this branch.
- Not audited: whether any *other* capability differs between the CLI and the
  MCP server. #116 named configuration; a broader front-door parity sweep is
  not in this change.

## Docs

The `data-gov` README holds the settings table and the file's location, and
now states that the MCP server resolves the same way. The MCP server README
points at that one place instead of restating a partial list, and documents
the startup-failure and stderr behaviour.

Refs #116