### PR TITLE
test(catalog): assert the cursor invariant, not the data it returns

### DIFF
--- a/data-gov-catalog/tests/integration_tests.rs
+++ b/data-gov-catalog/tests/integration_tests.rs
@@ -8,6 +8,7 @@
 //! cargo test -p data-gov-catalog --test integration_tests -- --ignored
 //! ```
 
+use data_gov_catalog::models::SearchResponse;
 use data_gov_catalog::{CatalogClient, Configuration, SearchParams, SortOrder, SpatialFilter};
 use std::sync::Arc;
 
@@ -54,34 +55,99 @@ async fn live_keywords_returns_counts() {
     assert!(kw.keywords.iter().all(|k| k.count > 0));
 }
 
+/// Live contract test: the `after` cursor walks forward through the result
+/// set rather than returning the same page again.
+///
+/// `after` is a declared parameter of `/search` in the API's own OpenAPI
+/// document (`https://catalog.data.gov/openapi.json`), which is the
+/// authoritative source for this API - the prose guide does not mention it.
+/// The cursor's value is the base64 of the last hit's `_sort` array, the
+/// standard `search_after` mechanism.
+///
+/// Asserts the invariant, not the data (#114). A cursor walk over a live,
+/// changing catalog cannot assert which datasets come back: the corpus is
+/// re-indexed continuously, and popularity feeds the sort. What must hold
+/// regardless is that the second page is a different page from the first and
+/// that the cursor moved.
+///
+/// Every failure below names what actually moved, because this test is
+/// `#[ignore]`d and runs only in the opt-in Live API Tests job - so when it
+/// does fail, nobody is watching, and the message is all a later reader gets.
 #[tokio::test]
-#[ignore]
+#[ignore = "hits the live data.gov Catalog API"]
 async fn live_pagination_advances_with_after_cursor() {
+    const QUERY: &str = "census";
+
     let client = live_client();
     let first = client
-        .search(SearchParams::new().q("census").per_page(2))
+        .search(SearchParams::new().q(QUERY).per_page(2))
         .await
-        .expect("page 1");
-    let after = first.after.clone().expect("first page has a cursor");
+        .expect("the first page of a live search");
+
+    assert!(
+        !first.results.is_empty(),
+        "{QUERY:?} returned nothing at all, so there is no cursor to follow. \
+         Either the catalog is empty or the query stopped matching - check \
+         the API before changing this test."
+    );
+
+    let cursor = first.after.clone().unwrap_or_else(|| {
+        panic!(
+            "the first page carried no `after` cursor, so pagination cannot \
+             start. {} result(s) came back for {QUERY:?}; the API omits the \
+             cursor on the last page, so this is only correct if the whole \
+             result set fits in one page of 2.",
+            first.results.len()
+        )
+    });
+
     let second = client
-        .search(SearchParams::new().q("census").per_page(2).after(after))
+        .search(
+            SearchParams::new()
+                .q(QUERY)
+                .per_page(2)
+                .after(cursor.clone()),
+        )
         .await
-        .expect("page 2");
-    assert!(!second.results.is_empty());
-    let first_ids: Vec<_> = first
-        .results
+        .expect("the second page of a live search");
+
+    assert!(
+        !second.results.is_empty(),
+        "following the cursor {cursor:?} returned an empty page, but the \
+         first page carried a cursor, which the API sends only when more \
+         results follow."
+    );
+
+    let slugs_of = |page: &SearchResponse| -> Vec<String> {
+        page.results
+            .iter()
+            .filter_map(|hit| hit.slug.clone())
+            .collect()
+    };
+    let first_slugs = slugs_of(&first);
+    let second_slugs = slugs_of(&second);
+
+    let repeated: Vec<&String> = first_slugs
         .iter()
-        .filter_map(|h| h.slug.as_ref())
-        .collect();
-    let second_ids: Vec<_> = second
-        .results
-        .iter()
-        .filter_map(|h| h.slug.as_ref())
+        .filter(|slug| second_slugs.contains(slug))
         .collect();
     assert!(
-        first_ids.iter().all(|id| !second_ids.contains(id)),
-        "pages should not overlap"
+        repeated.is_empty(),
+        "the cursor did not advance: {repeated:?} appeared on both pages. \
+         Page 1 was {first_slugs:?}, page 2 was {second_slugs:?}."
     );
+
+    // The cursor is the sort position of the last hit consumed, so a second
+    // page that reports the same one has not moved - which would loop a
+    // caller paging to the end forever, the failure this test exists to
+    // catch.
+    if let Some(next) = second.after.as_ref() {
+        assert_ne!(
+            next, &cursor,
+            "the second page returned the same cursor it was given, so a \
+             caller paging through the whole result set would never finish."
+        );
+    }
 }
 
 /// Live contract test: a slug that exists resolves, including slugs that


### PR DESCRIPTION
Addresses #114. One of its four acceptance boxes cannot be ticked honestly;
see below.

## It does not fail now

Measured 2026-08-15 against `catalog.data.gov`:

- `live_pagination_advances_with_after_cursor`: **10/10 consecutive runs pass**
- the whole live suite (`just test-live`): **green**, 11/11 in the catalog
  crate's integration target

The issue reported it failing and confirmed it was pre-existing rather than a
regression, so it did fail then. **I could not reproduce it, and therefore
cannot say what the cause was.** Recording that rather than inventing one -
the alternative is a plausible story that a later reader trusts.

## What could be settled: the client is not wrong

The issue asked whether the test's expectation or the API's behaviour was
wrong, and said to check the OpenAPI document before changing either side.
Done:

- `after` is a **declared parameter of `/search`** in
  `https://catalog.data.gov/openapi.json`, which is authoritative for this API
  where the prose guide is not - and the prose guide does not mention it at
  all, which is what made it look undocumented.
- The cursor's value is the base64 of the last hit's `_sort` array: standard
  Elasticsearch `search_after`.

```
$ curl -s 'https://catalog.data.gov/search?q=census&per_page=2'
after: WzY1LjgzMTkyNCwyMywiZWE2MDliMTUt...
  slug: 2020-census-to-police-district-crosswalk | _sort: [69.92629, 8, '2c814ac7-...']
  slug: 1950-census-official-1950-census-website | _sort: [65.831924, 23, 'ea609b15-...']
```

So **no client change is needed**, and there is nothing to note in the
changelog on that front.

## What is fixed: the test

The test was the remaining problem, and it is the half of #114 that was
actionable. It asserted that two named pages of a live, continuously
re-indexed catalog do not overlap - data that moves - and when they did, it
said only `pages should not overlap`.

It now asserts the invariant: the second page is a different page, and the
cursor moved. Every failure names what actually moved - which slug repeated,
what each page held, whether the cursor came back unchanged, whether the first
page carried a cursor at all.

That matters more here than in a hermetic test. This one is `#[ignore]`d and
runs only in the opt-in Live API Tests job, so when it fails **nobody is
watching**, and the message is all a later reader gets. #114 exists because
that already happened once.

## Mutation check, and a trap worth recording

Removing `.after(cursor)` so page two repeats page one fails the test and
names both slugs:

```
the cursor did not advance: ["2020-census-to-police-district-crosswalk",
"1950-census-official-1950-census-website"] appeared on both pages.
```

**The first attempt at that mutation silently did not apply.** `cargo fmt` had
reflowed the line the patch matched on, so the patch matched nothing and the
run came back green - indistinguishable from a test that cannot catch the
mutation. The mutation was confirmed present in the file before the run was
trusted, which is the check CLAUDE.md asks for and the reason it asks for it.

## Acceptance

- [ ] **The cause is determined and recorded - test wrong, or API changed.**
      Not ticked. It cannot be reproduced; what is known is recorded on the
      issue.
- [x] The test passes against the live API, asserting an invariant rather than
      data that moves
- [x] If the API's cursor behaviour differs from what the client assumes, the
      client is fixed too - it does not differ, per the OpenAPI document, so
      there is nothing to change or to note
- [ ] Consider whether the live suite should report somewhere visible when it
      fails, given it is deliberately non-gating. **Not done, deliberately** -
      it is a CI-design change rather than a test fix, and it should not ride
      into a release inside a test PR.

Suggest leaving #114 open for those two boxes.

Refs #114