### PR TITLE
docs(ckan): document every public item, and deny missing_docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Error::downcast_mut()`.
 
 ### Added
+- **`data-gov-ckan`'s models are documented** (#118). Every public item in the
+  crate now carries a doc comment: what each CKAN concept is, and the things
+  that are not guessable from a field name - that `Group` models both groups
+  and organizations and `is_organization` is the only thing separating them,
+  that a failed action is still HTTP 200 so `success` is what marks it, that a
+  validation failure does not use `ErrorResponseError` because it replaces
+  `message` with per-field arrays, and that the utility API capitalises its
+  members, which is why the autocomplete envelopes nest through `ResultSet`.
+  The `id` and `size` fields keep the notes explaining why they are `String`
+  and `i64` rather than `uuid::Uuid` and `i32` (#63, #62).
 - **`data_gov::ui` is documented** (#59). The download progress-reporting port
   - [`StatusReporter`] and its five event structs - carried no documentation at
   all, so a consumer implementing it had to read the client's source to learn
@@ -458,12 +468,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   had no `# Errors` section now have one naming the variants that call path can
   actually produce. CLAUDE.md required the section; nothing enforced it, so it
   was missing across three crates.
-- **`missing_docs` is denied in `data-gov-catalog`, `data-gov`, and
-  `data-gov-mcp-server`** (#59), clearing 100 undocumented public items: the 60
-  DCAT-US 3 model fields in the catalog crate, and in `data-gov` the whole
-  `ui` module, the error variants' fields, and the `client` and `error` module
-  docs. `data-gov-ckan` is deliberately not covered yet - its 170 model fields
-  are tracked in #118, and it is the crate data.gov no longer uses.
+- **`missing_docs` is denied in every crate** (#59, #118), clearing 273
+  undocumented public items. In `data-gov-catalog`, the 60 DCAT-US 3 model
+  fields; in `data-gov`, the whole `ui` module, the error variants' fields, and
+  the `client` and `error` module docs; in `data-gov-ckan`, all 173 remaining
+  items across its 29 model files and its two crate-root modules.
 
 - **Working docs are plain ASCII, and CI enforces it.** `CLAUDE.md` and the
   `justfile` used em-dashes and arrow glyphs throughout - characters nobody

--- a/data-gov-ckan/src/lib.rs
+++ b/data-gov-ckan/src/lib.rs
@@ -14,6 +14,9 @@
 //! instances), and the client works unchanged against any compliant CKAN
 //! deployment. Point [`Configuration::base_path`] at your target instance.
 
+// Every public item in this crate carries a doc comment, and that is
+// enforced rather than remembered (#118).
+#![deny(missing_docs)]
 #![allow(clippy::too_many_arguments)]
 
 // A TLS backend is not optional: every endpoint this crate talks to is HTTPS.
@@ -26,7 +29,9 @@ compile_error!(
      Building with `default-features = false` and neither feature produces a client that \
      cannot complete any HTTPS request."
 );
+/// The HTTP client, its configuration, and its error type.
 pub mod client;
+/// Types modelling the CKAN Action API's JSON payloads.
 pub mod models;
 
 // Re-export the ergonomic client and configuration for easy access

--- a/data-gov-ckan/src/models/_util_dataset_autocomplete_get_200_response.rs
+++ b/data-gov-ckan/src/models/_util_dataset_autocomplete_get_200_response.rs
@@ -11,13 +11,20 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The outer envelope from the utility API's dataset-autocomplete endpoint.
+///
+/// The utility API (`/api/{version}/util/...`) predates the v3 Action
+/// API and capitalises its members, which is why this nests through
+/// `ResultSet` before reaching anything useful.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilDatasetAutocompleteGet200Response {
+    /// The `ResultSet` member holding the suggestions.
     #[serde(rename = "ResultSet", skip_serializing_if = "Option::is_none")]
     pub result_set: Option<Box<models::UtilDatasetAutocompleteGet200ResponseResultSet>>,
 }
 
 impl UtilDatasetAutocompleteGet200Response {
+    /// Create an empty [`UtilDatasetAutocompleteGet200Response`]; every field starts as `None`.
     pub fn new() -> UtilDatasetAutocompleteGet200Response {
         UtilDatasetAutocompleteGet200Response { result_set: None }
     }

--- a/data-gov-ckan/src/models/_util_dataset_autocomplete_get_200_response_result_set.rs
+++ b/data-gov-ckan/src/models/_util_dataset_autocomplete_get_200_response_result_set.rs
@@ -11,13 +11,16 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The `ResultSet` member of the utility dataset-autocomplete envelope.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilDatasetAutocompleteGet200ResponseResultSet {
+    /// The suggestions themselves.
     #[serde(rename = "Result", skip_serializing_if = "Option::is_none")]
     pub result: Option<Vec<models::DatasetAutocomplete>>,
 }
 
 impl UtilDatasetAutocompleteGet200ResponseResultSet {
+    /// Create an empty [`UtilDatasetAutocompleteGet200ResponseResultSet`]; every field starts as `None`.
     pub fn new() -> UtilDatasetAutocompleteGet200ResponseResultSet {
         UtilDatasetAutocompleteGet200ResponseResultSet { result: None }
     }

--- a/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response.rs
+++ b/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response.rs
@@ -11,13 +11,20 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The outer envelope from the utility API's resource-format-autocomplete endpoint.
+///
+/// The utility API (`/api/{version}/util/...`) predates the v3 Action
+/// API and capitalises its members, which is why this nests through
+/// `ResultSet` before reaching anything useful.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilResourceFormatAutocompleteGet200Response {
+    /// The `ResultSet` member holding the suggestions.
     #[serde(rename = "ResultSet", skip_serializing_if = "Option::is_none")]
     pub result_set: Option<Box<models::UtilResourceFormatAutocompleteGet200ResponseResultSet>>,
 }
 
 impl UtilResourceFormatAutocompleteGet200Response {
+    /// Create an empty [`UtilResourceFormatAutocompleteGet200Response`]; every field starts as `None`.
     pub fn new() -> UtilResourceFormatAutocompleteGet200Response {
         UtilResourceFormatAutocompleteGet200Response { result_set: None }
     }

--- a/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response_result_set.rs
+++ b/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response_result_set.rs
@@ -11,14 +11,17 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The `ResultSet` member of the utility resource-format-autocomplete envelope.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilResourceFormatAutocompleteGet200ResponseResultSet {
+    /// The suggestions themselves.
     #[serde(rename = "Result", skip_serializing_if = "Option::is_none")]
     pub result:
         Option<Vec<models::UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner>>,
 }
 
 impl UtilResourceFormatAutocompleteGet200ResponseResultSet {
+    /// Create an empty [`UtilResourceFormatAutocompleteGet200ResponseResultSet`]; every field starts as `None`.
     pub fn new() -> UtilResourceFormatAutocompleteGet200ResponseResultSet {
         UtilResourceFormatAutocompleteGet200ResponseResultSet { result: None }
     }

--- a/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response_result_set_result_inner.rs
+++ b/data-gov-ckan/src/models/_util_resource_format_autocomplete_get_200_response_result_set_result_inner.rs
@@ -10,13 +10,16 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One format suggestion inside the utility resource-format-autocomplete envelope.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner {
+    /// The suggested format.
     #[serde(rename = "Format", skip_serializing_if = "Option::is_none")]
     pub format: Option<String>,
 }
 
 impl UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner {
+    /// Create an empty [`UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner`]; every field starts as `None`.
     pub fn new() -> UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner {
         UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner { format: None }
     }

--- a/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response.rs
+++ b/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response.rs
@@ -11,13 +11,20 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The outer envelope from the utility API's tag-autocomplete endpoint.
+///
+/// The utility API (`/api/{version}/util/...`) predates the v3 Action
+/// API and capitalises its members, which is why this nests through
+/// `ResultSet` before reaching anything useful.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilTagAutocompleteGet200Response {
+    /// The `ResultSet` member holding the suggestions.
     #[serde(rename = "ResultSet", skip_serializing_if = "Option::is_none")]
     pub result_set: Option<Box<models::UtilTagAutocompleteGet200ResponseResultSet>>,
 }
 
 impl UtilTagAutocompleteGet200Response {
+    /// Create an empty [`UtilTagAutocompleteGet200Response`]; every field starts as `None`.
     pub fn new() -> UtilTagAutocompleteGet200Response {
         UtilTagAutocompleteGet200Response { result_set: None }
     }

--- a/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response_result_set.rs
+++ b/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response_result_set.rs
@@ -11,13 +11,16 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The `ResultSet` member of the utility tag-autocomplete envelope.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilTagAutocompleteGet200ResponseResultSet {
+    /// The suggestions themselves.
     #[serde(rename = "Result", skip_serializing_if = "Option::is_none")]
     pub result: Option<Vec<models::UtilTagAutocompleteGet200ResponseResultSetResultInner>>,
 }
 
 impl UtilTagAutocompleteGet200ResponseResultSet {
+    /// Create an empty [`UtilTagAutocompleteGet200ResponseResultSet`]; every field starts as `None`.
     pub fn new() -> UtilTagAutocompleteGet200ResponseResultSet {
         UtilTagAutocompleteGet200ResponseResultSet { result: None }
     }

--- a/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response_result_set_result_inner.rs
+++ b/data-gov-ckan/src/models/_util_tag_autocomplete_get_200_response_result_set_result_inner.rs
@@ -10,13 +10,16 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One tag suggestion inside the utility tag-autocomplete envelope.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UtilTagAutocompleteGet200ResponseResultSetResultInner {
+    /// The suggested tag.
     #[serde(rename = "Name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 impl UtilTagAutocompleteGet200ResponseResultSetResultInner {
+    /// Create an empty [`UtilTagAutocompleteGet200ResponseResultSetResultInner`]; every field starts as `None`.
     pub fn new() -> UtilTagAutocompleteGet200ResponseResultSetResultInner {
         UtilTagAutocompleteGet200ResponseResultSetResultInner { name: None }
     }

--- a/data-gov-ckan/src/models/action_response.rs
+++ b/data-gov-ckan/src/models/action_response.rs
@@ -10,6 +10,13 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The envelope every Action API call returns.
+///
+/// CKAN wraps every response, success or failure, in this shape: `help`
+/// points at the action's documentation, `success` says whether it worked,
+/// and the payload sits in [`Self::result`] or the failure in
+/// [`Self::error`]. A failed action is still HTTP 200, so `success` is what
+/// distinguishes them, not the status code.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ActionResponse {
     /// URL to documentation for this action
@@ -37,6 +44,9 @@ pub struct ActionResponse {
 }
 
 impl ActionResponse {
+    /// Create an [`ActionResponse`] from the three members CKAN always sends.
+    ///
+    /// [`Self::changed_entities`] and [`Self::error`] start as `None`.
     pub fn new(help: String, success: bool, result: Option<serde_json::Value>) -> ActionResponse {
         ActionResponse {
             help,

--- a/data-gov-ckan/src/models/api_version_response.rs
+++ b/data-gov-ckan/src/models/api_version_response.rs
@@ -10,6 +10,10 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The response from the legacy `/api/1` version endpoint.
+///
+/// The only thing that endpoint reports is which API version the portal
+/// serves.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ApiVersionResponse {
     /// API version number
@@ -18,6 +22,7 @@ pub struct ApiVersionResponse {
 }
 
 impl ApiVersionResponse {
+    /// Create an [`ApiVersionResponse`] carrying `version`.
     pub fn new(version: i32) -> ApiVersionResponse {
         ApiVersionResponse { version }
     }

--- a/data-gov-ckan/src/models/dataset_autocomplete.rs
+++ b/data-gov-ckan/src/models/dataset_autocomplete.rs
@@ -10,21 +10,35 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One dataset suggestion from the dataset-autocomplete endpoint.
+///
+/// Every field is optional because the endpoint returns only what it
+/// matched on, which varies with the query.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DatasetAutocomplete {
+    /// Identifier of the suggested dataset.
+    ///
+    /// CKAN's `id` column is unconstrained text; see
+    /// [`crate::models::Package::id`] for why this is a `String` rather than a
+    /// `uuid::Uuid`.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// URL-friendly name (slug) of the suggested dataset.
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Human-readable title of the suggested dataset.
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// The matched text, as the portal would display it.
     #[serde(rename = "match_displayed", skip_serializing_if = "Option::is_none")]
     pub match_displayed: Option<String>,
+    /// Which field the query matched, such as `title` or `name`.
     #[serde(rename = "match_field", skip_serializing_if = "Option::is_none")]
     pub match_field: Option<String>,
 }
 
 impl DatasetAutocomplete {
+    /// Create an empty [`DatasetAutocomplete`]; every field starts as `None`.
     pub fn new() -> DatasetAutocomplete {
         DatasetAutocomplete {
             id: None,

--- a/data-gov-ckan/src/models/error_response.rs
+++ b/data-gov-ckan/src/models/error_response.rs
@@ -11,17 +11,25 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The envelope CKAN returns when an action fails.
+///
+/// Note that a failed action is still HTTP 200: [`Self::success`] is what
+/// marks the failure, not the status code.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ErrorResponse {
+    /// URL of the documentation for the action that failed.
     #[serde(rename = "help")]
     pub help: String,
+    /// Always `false` on this envelope.
     #[serde(rename = "success")]
     pub success: bool,
+    /// What went wrong.
     #[serde(rename = "error")]
     pub error: Box<models::ErrorResponseError>,
 }
 
 impl ErrorResponse {
+    /// Create an [`ErrorResponse`] from its three members.
     pub fn new(help: String, success: bool, error: models::ErrorResponseError) -> ErrorResponse {
         ErrorResponse {
             help,

--- a/data-gov-ckan/src/models/error_response_error.rs
+++ b/data-gov-ckan/src/models/error_response_error.rs
@@ -10,6 +10,12 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The error object carried by a failed action's envelope.
+///
+/// This is CKAN's fixed failure shape. A *validation* failure does not use
+/// it: that replaces `message` with one array of messages per rejected
+/// field, which is why [`crate::models::ActionResponse::error`] keeps a raw
+/// [`serde_json::Value`] rather than this type.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ErrorResponseError {
     /// The type of error
@@ -21,6 +27,7 @@ pub struct ErrorResponseError {
 }
 
 impl ErrorResponseError {
+    /// Create an [`ErrorResponseError`] from the two members CKAN always sends.
     pub fn new(__type: String, message: String) -> ErrorResponseError {
         ErrorResponseError { __type, message }
     }

--- a/data-gov-ckan/src/models/extra.rs
+++ b/data-gov-ckan/src/models/extra.rs
@@ -3,13 +3,20 @@ use serde::{Deserialize, Serialize};
 /// Represents an extra key-value pair in CKAN datasets
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Extra {
+    /// Name of the extra field, chosen by whoever published the dataset.
     #[serde(rename = "key")]
     pub key: String,
+    /// The value.
+    ///
+    /// Untyped because `extras` is CKAN's escape hatch for whatever a portal
+    /// wants to attach: publishers send strings, numbers, booleans, and nested
+    /// objects through the same field.
     #[serde(rename = "value")]
     pub value: serde_json::Value,
 }
 
 impl Extra {
+    /// Create an [`Extra`] pairing `key` with `value`.
     pub fn new(key: String, value: serde_json::Value) -> Extra {
         Extra { key, value }
     }

--- a/data-gov-ckan/src/models/group.rs
+++ b/data-gov-ckan/src/models/group.rs
@@ -11,6 +11,11 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// A group or an organization.
+///
+/// CKAN models both with one type and tells them apart with
+/// [`Self::is_organization`]. An organization owns datasets and controls who
+/// may edit them; a group is a looser collection a dataset can belong to.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Group {
     /// Unique identifier for the group or organization.
@@ -34,30 +39,49 @@ pub struct Group {
     /// URL to group image
     #[serde(rename = "image_url", skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
+    /// Fully-qualified URL of the image, resolved by the portal.
+    ///
+    /// [`Self::image_url`] may be relative to the site, so prefer this one when
+    /// fetching the image.
     #[serde(rename = "image_display_url", skip_serializing_if = "Option::is_none")]
     pub image_display_url: Option<String>,
+    /// The group type, `group` or `organization` by default.
+    ///
+    /// A portal with a custom group-type extension can send others.
     #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub r#type: Option<String>,
+    /// Whether the group is active or has been deleted.
     #[serde(rename = "state", skip_serializing_if = "Option::is_none")]
     pub state: Option<State>,
+    /// Whether a site administrator has approved the group.
     #[serde(rename = "approval_status", skip_serializing_if = "Option::is_none")]
     pub approval_status: Option<String>,
+    /// Whether this is an organization rather than a plain group.
+    ///
+    /// This is the only thing separating the two, since CKAN returns both
+    /// through this type.
     #[serde(rename = "is_organization", skip_serializing_if = "Option::is_none")]
     pub is_organization: Option<bool>,
+    /// When the group was created, as an ISO 8601 timestamp.
     #[serde(rename = "created", skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
     /// Number of packages in this group
     #[serde(rename = "package_count", skip_serializing_if = "Option::is_none")]
     pub package_count: Option<i32>,
+    /// Members of the group, present only when the call asked for them.
     #[serde(rename = "users", skip_serializing_if = "Option::is_none")]
     pub users: Option<Vec<models::User>>,
+    /// Parent groups this group belongs to.
     #[serde(rename = "groups", skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<models::Group>>,
+    /// Free-form key/value pairs attached to the group.
     #[serde(rename = "extras", skip_serializing_if = "Option::is_none")]
     pub extras: Option<std::collections::HashMap<String, String>>,
 }
 
 impl Group {
+    /// Create a [`Group`] with the required `name`; every other field starts as
+    /// `None`.
     pub fn new(name: String) -> Group {
         Group {
             id: None,
@@ -78,13 +102,17 @@ impl Group {
         }
     }
 }
+/// Whether a group is live or has been deleted.
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
 pub enum State {
+    /// The group is live.
     #[serde(rename = "active")]
     #[default]
     Active,
+    /// The group has been deleted. CKAN deletes softly, so the record is still
+    /// returned.
     #[serde(rename = "deleted")]
     Deleted,
 }

--- a/data-gov-ckan/src/models/group_autocomplete.rs
+++ b/data-gov-ckan/src/models/group_autocomplete.rs
@@ -10,17 +10,25 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One group suggestion from `group_autocomplete`.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GroupAutocomplete {
+    /// Identifier of the suggested group.
+    ///
+    /// CKAN's `id` column is unconstrained text; see
+    /// [`crate::models::Package::id`] for why this is a `String`.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// URL-friendly name (slug) of the suggested group.
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Human-readable title of the suggested group.
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
 
 impl GroupAutocomplete {
+    /// Create an empty [`GroupAutocomplete`]; every field starts as `None`.
     pub fn new() -> GroupAutocomplete {
         GroupAutocomplete {
             id: None,

--- a/data-gov-ckan/src/models/license.rs
+++ b/data-gov-ckan/src/models/license.rs
@@ -10,31 +10,50 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One licence from the portal's licence register.
+///
+/// The register is configurable per portal, so the set of ids a deployment
+/// offers is not fixed and the compliance flags below reflect that
+/// portal's own register rather than a canonical source.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct License {
+    /// Identifier the portal uses for this licence, such as `cc-by`.
+    ///
+    /// This is the value that appears in
+    /// [`crate::models::Package::license_id`].
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Human-readable name of the licence.
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// URL of the licence text.
     #[serde(rename = "url", skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Who maintains the licence.
     #[serde(rename = "maintainer", skip_serializing_if = "Option::is_none")]
     pub maintainer: Option<String>,
+    /// Licence family the portal groups this one under.
     #[serde(rename = "family", skip_serializing_if = "Option::is_none")]
     pub family: Option<String>,
+    /// Whether the register marks this licence as conforming to the Open Definition.
     #[serde(rename = "is_okd_compliant", skip_serializing_if = "Option::is_none")]
     pub is_okd_compliant: Option<bool>,
+    /// Whether the register marks this licence as OSI-approved.
     #[serde(rename = "is_osi_compliant", skip_serializing_if = "Option::is_none")]
     pub is_osi_compliant: Option<bool>,
+    /// Whether the licence is intended for content.
     #[serde(rename = "domain_content", skip_serializing_if = "Option::is_none")]
     pub domain_content: Option<bool>,
+    /// Whether the licence is intended for data.
     #[serde(rename = "domain_data", skip_serializing_if = "Option::is_none")]
     pub domain_data: Option<bool>,
+    /// Whether the licence is intended for software.
     #[serde(rename = "domain_software", skip_serializing_if = "Option::is_none")]
     pub domain_software: Option<bool>,
 }
 
 impl License {
+    /// Create an empty [`License`]; every field starts as `None`.
     pub fn new() -> License {
         License {
             id: None,

--- a/data-gov-ckan/src/models/mod.rs
+++ b/data-gov-ckan/src/models/mod.rs
@@ -1,56 +1,84 @@
+/// The envelope every Action API call returns.
 pub mod action_response;
 pub use self::action_response::ActionResponse;
+/// The response from the legacy `/api/1` version endpoint.
 pub mod api_version_response;
 pub use self::api_version_response::ApiVersionResponse;
+/// One dataset suggestion from the dataset-autocomplete endpoint.
 pub mod dataset_autocomplete;
 pub use self::dataset_autocomplete::DatasetAutocomplete;
+/// The envelope CKAN returns when an action fails.
 pub mod error_response;
 pub use self::error_response::ErrorResponse;
+/// The error object carried by a failed action's envelope.
 pub mod error_response_error;
 pub use self::error_response_error::ErrorResponseError;
+/// One free-form key/value pair attached to a dataset.
 pub mod extra;
 pub use self::extra::Extra;
+/// A group or an organization - CKAN models both with one type.
 pub mod group;
 pub use self::group::Group;
+/// One group suggestion from `group_autocomplete`.
 pub mod group_autocomplete;
 pub use self::group_autocomplete::GroupAutocomplete;
+/// One licence from the portal's licence register.
 pub mod license;
 pub use self::license::License;
+/// One organization suggestion from `organization_autocomplete`.
 pub mod organization_autocomplete;
 pub use self::organization_autocomplete::OrganizationAutocomplete;
+/// A dataset, which CKAN calls a package.
 pub mod package;
 pub use self::package::Package;
+/// The result envelope from `package_search`.
 pub mod package_search_result;
 pub use self::package_search_result::PackageSearchResult;
+/// One file or API endpoint attached to a dataset.
 pub mod resource;
 pub use self::resource::Resource;
+/// What the portal reports about itself.
 pub mod status_info;
 pub use self::status_info::StatusInfo;
+/// One tag attached to a dataset.
 pub mod tag;
 pub use self::tag::Tag;
+/// A user account.
 pub mod user;
 pub use self::user::User;
+/// One user suggestion from `user_autocomplete`.
 pub mod user_autocomplete;
 pub use self::user_autocomplete::UserAutocomplete;
+/// The outer envelope from the utility API's dataset-autocomplete endpoint.
 pub mod _util_dataset_autocomplete_get_200_response;
 pub use self::_util_dataset_autocomplete_get_200_response::UtilDatasetAutocompleteGet200Response;
+/// The `ResultSet` member of the utility dataset-autocomplete envelope.
 pub mod _util_dataset_autocomplete_get_200_response_result_set;
 pub use self::_util_dataset_autocomplete_get_200_response_result_set::UtilDatasetAutocompleteGet200ResponseResultSet;
+/// The outer envelope from the utility API's resource-format-autocomplete endpoint.
 pub mod _util_resource_format_autocomplete_get_200_response;
 pub use self::_util_resource_format_autocomplete_get_200_response::UtilResourceFormatAutocompleteGet200Response;
+/// The `ResultSet` member of the utility resource-format-autocomplete envelope.
 pub mod _util_resource_format_autocomplete_get_200_response_result_set;
 pub use self::_util_resource_format_autocomplete_get_200_response_result_set::UtilResourceFormatAutocompleteGet200ResponseResultSet;
+/// One format suggestion inside the utility resource-format-autocomplete envelope.
 pub mod _util_resource_format_autocomplete_get_200_response_result_set_result_inner;
 pub use self::_util_resource_format_autocomplete_get_200_response_result_set_result_inner::UtilResourceFormatAutocompleteGet200ResponseResultSetResultInner;
+/// The outer envelope from the utility API's tag-autocomplete endpoint.
 pub mod _util_tag_autocomplete_get_200_response;
 pub use self::_util_tag_autocomplete_get_200_response::UtilTagAutocompleteGet200Response;
+/// The `ResultSet` member of the utility tag-autocomplete envelope.
 pub mod _util_tag_autocomplete_get_200_response_result_set;
 pub use self::_util_tag_autocomplete_get_200_response_result_set::UtilTagAutocompleteGet200ResponseResultSet;
+/// One tag suggestion inside the utility tag-autocomplete envelope.
 pub mod _util_tag_autocomplete_get_200_response_result_set_result_inner;
 pub use self::_util_tag_autocomplete_get_200_response_result_set_result_inner::UtilTagAutocompleteGet200ResponseResultSetResultInner;
+/// The envelope CKAN returns when an action fails validation.
 pub mod validation_error_response;
 pub use self::validation_error_response::ValidationErrorResponse;
+/// The error object carried by a validation failure.
 pub mod validation_error_response_error;
 pub use self::validation_error_response_error::ValidationErrorResponseError;
+/// A controlled vocabulary that tags may belong to.
 pub mod vocabulary;
 pub use self::vocabulary::Vocabulary;

--- a/data-gov-ckan/src/models/organization_autocomplete.rs
+++ b/data-gov-ckan/src/models/organization_autocomplete.rs
@@ -10,17 +10,25 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One organization suggestion from `organization_autocomplete`.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OrganizationAutocomplete {
+    /// Identifier of the suggested organization.
+    ///
+    /// CKAN's `id` column is unconstrained text, and organizations are where
+    /// this bites in practice - see [`crate::models::Group::id`].
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// URL-friendly name (slug) of the suggested organization.
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Human-readable title of the suggested organization.
     #[serde(rename = "title", skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
 }
 
 impl OrganizationAutocomplete {
+    /// Create an empty [`OrganizationAutocomplete`]; every field starts as `None`.
     pub fn new() -> OrganizationAutocomplete {
         OrganizationAutocomplete {
             id: None,

--- a/data-gov-ckan/src/models/package.rs
+++ b/data-gov-ckan/src/models/package.rs
@@ -11,6 +11,12 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// A dataset, which CKAN calls a package.
+///
+/// The unit a portal publishes: metadata plus the files and endpoints in
+/// [`Self::resources`]. Almost every field is optional, because which
+/// metadata a publisher fills in varies widely between portals and even
+/// between datasets on one portal.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Package {
     /// Unique identifier for the dataset.
@@ -87,10 +93,16 @@ pub struct Package {
     /// When the dataset metadata was last modified
     #[serde(rename = "metadata_modified", skip_serializing_if = "Option::is_none")]
     pub metadata_modified: Option<String>,
+    /// The files and API endpoints that carry the dataset's actual data.
+    ///
+    /// Absent rather than empty when a call did not ask for them - `package_show`
+    /// includes them, some search responses do not.
     #[serde(rename = "resources", skip_serializing_if = "Option::is_none")]
     pub resources: Option<Vec<models::Resource>>,
+    /// Tags attached to the dataset.
     #[serde(rename = "tags", skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
+    /// Groups the dataset belongs to.
     #[serde(rename = "groups", skip_serializing_if = "Option::is_none")]
     pub groups: Option<Vec<models::Group>>,
     /// Additional metadata key-value pairs
@@ -102,6 +114,8 @@ pub struct Package {
 }
 
 impl Package {
+    /// Create a [`Package`] with the required `name`; every other field starts
+    /// as `None`.
     pub fn new(name: String) -> Package {
         Package {
             id: None,
@@ -140,11 +154,15 @@ impl Package {
     Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
 pub enum State {
+    /// The dataset is published and live.
     #[serde(rename = "active")]
     #[default]
     Active,
+    /// The dataset has been deleted. CKAN deletes softly, so the record is
+    /// still returned.
     #[serde(rename = "deleted")]
     Deleted,
+    /// The dataset is part-created and not yet published.
     #[serde(rename = "draft")]
     Draft,
 }

--- a/data-gov-ckan/src/models/package_search_result.rs
+++ b/data-gov-ckan/src/models/package_search_result.rs
@@ -11,11 +11,17 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The result envelope from `package_search`.
+///
+/// [`Self::count`] is the total number of matches, not the number in
+/// [`Self::results`] - paging through the set means reading `count` and
+/// advancing `start`.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PackageSearchResult {
     /// Total number of matching packages
     #[serde(rename = "count", skip_serializing_if = "Option::is_none")]
     pub count: Option<i32>,
+    /// The datasets on this page.
     #[serde(rename = "results", skip_serializing_if = "Option::is_none")]
     pub results: Option<Vec<models::Package>>,
     /// Faceted search results
@@ -27,6 +33,7 @@ pub struct PackageSearchResult {
 }
 
 impl PackageSearchResult {
+    /// Create an empty [`PackageSearchResult`]; every field starts as `None`.
     pub fn new() -> PackageSearchResult {
         PackageSearchResult {
             count: None,

--- a/data-gov-ckan/src/models/resource.rs
+++ b/data-gov-ckan/src/models/resource.rs
@@ -10,6 +10,11 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One file or API endpoint attached to a dataset.
+///
+/// A dataset's data lives here rather than on the dataset itself: one
+/// dataset commonly carries the same data as several resources in different
+/// formats.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Resource {
     /// Unique identifier for the resource.
@@ -68,10 +73,13 @@ pub struct Resource {
         skip_serializing_if = "Option::is_none"
     )]
     pub size: Option<i64>,
+    /// When the resource was created, as an ISO 8601 timestamp.
     #[serde(rename = "created", skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
+    /// When the resource's file was last changed, as an ISO 8601 timestamp.
     #[serde(rename = "last_modified", skip_serializing_if = "Option::is_none")]
     pub last_modified: Option<String>,
+    /// When the portal last refreshed its cached copy, as an ISO 8601 timestamp.
     #[serde(rename = "cache_last_updated", skip_serializing_if = "Option::is_none")]
     pub cache_last_updated: Option<String>,
     /// Whether the resource is in the datastore
@@ -80,6 +88,7 @@ pub struct Resource {
 }
 
 impl Resource {
+    /// Create an empty [`Resource`]; every field starts as `None`.
     pub fn new() -> Resource {
         Resource {
             id: None,

--- a/data-gov-ckan/src/models/status_info.rs
+++ b/data-gov-ckan/src/models/status_info.rs
@@ -10,25 +10,44 @@
 
 use serde::{Deserialize, Serialize};
 
+/// What the portal reports about itself.
+///
+/// Returned by `status_show`. Useful mainly for [`Self::ckan_version`] and
+/// [`Self::extensions`], which together say which actions a deployment
+/// actually supports.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StatusInfo {
+    /// The portal's title.
     #[serde(rename = "site_title", skip_serializing_if = "Option::is_none")]
     pub site_title: Option<String>,
+    /// The portal's description.
     #[serde(rename = "site_description", skip_serializing_if = "Option::is_none")]
     pub site_description: Option<String>,
+    /// The portal's own base URL.
     #[serde(rename = "site_url", skip_serializing_if = "Option::is_none")]
     pub site_url: Option<String>,
+    /// Which CKAN release the portal runs.
+    ///
+    /// Worth checking before relying on a newer action: this crate targets the
+    /// v3 Action API, but individual actions came in at different releases.
     #[serde(rename = "ckan_version", skip_serializing_if = "Option::is_none")]
     pub ckan_version: Option<String>,
+    /// Where the portal sends its error reports.
     #[serde(rename = "error_emails_to", skip_serializing_if = "Option::is_none")]
     pub error_emails_to: Option<String>,
+    /// The portal's default locale.
     #[serde(rename = "locale_default", skip_serializing_if = "Option::is_none")]
     pub locale_default: Option<String>,
+    /// Extensions the portal has enabled.
+    ///
+    /// An extension can add actions and fields beyond core CKAN, which is one
+    /// reason a response may carry more than these models name.
     #[serde(rename = "extensions", skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<String>>,
 }
 
 impl StatusInfo {
+    /// Create an empty [`StatusInfo`]; every field starts as `None`.
     pub fn new() -> StatusInfo {
         StatusInfo {
             site_title: None,

--- a/data-gov-ckan/src/models/tag.rs
+++ b/data-gov-ckan/src/models/tag.rs
@@ -10,6 +10,10 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One tag attached to a dataset.
+///
+/// A tag with no [`Self::vocabulary_id`] is free-form. One that names a
+/// vocabulary is drawn from that controlled list instead.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Tag {
     /// Unique identifier for the tag.
@@ -24,6 +28,7 @@ pub struct Tag {
     /// Display name for the tag
     #[serde(rename = "display_name", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// Whether the tag is active or has been deleted.
     #[serde(rename = "state", skip_serializing_if = "Option::is_none")]
     pub state: Option<State>,
     /// ID of vocabulary this tag belongs to
@@ -32,6 +37,8 @@ pub struct Tag {
 }
 
 impl Tag {
+    /// Create a [`Tag`] with the required `name`; every other field starts as
+    /// `None`.
     pub fn new(name: String) -> Tag {
         Tag {
             id: None,
@@ -42,13 +49,17 @@ impl Tag {
         }
     }
 }
+/// Whether a tag is live or has been deleted.
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
 pub enum State {
+    /// The tag is live.
     #[serde(rename = "active")]
     #[default]
     Active,
+    /// The tag has been deleted. CKAN deletes softly, so the record is still
+    /// returned.
     #[serde(rename = "deleted")]
     Deleted,
 }

--- a/data-gov-ckan/src/models/user.rs
+++ b/data-gov-ckan/src/models/user.rs
@@ -10,6 +10,11 @@
 
 use serde::{Deserialize, Serialize};
 
+/// A user account.
+///
+/// How much of this a caller sees depends on who is asking:
+/// [`Self::email`] and [`Self::sysadmin`] are withheld from anonymous
+/// requests.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct User {
     /// Unique identifier for the user.
@@ -27,20 +32,30 @@ pub struct User {
     /// Computed display name
     #[serde(rename = "display_name", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
+    /// The user's email address.
+    ///
+    /// Returned only to a caller entitled to see it - anonymous requests get
+    /// `None` rather than an error.
     #[serde(rename = "email", skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
     /// User biography/about text
     #[serde(rename = "about", skip_serializing_if = "Option::is_none")]
     pub about: Option<String>,
+    /// When the account was created, as an ISO 8601 timestamp.
     #[serde(rename = "created", skip_serializing_if = "Option::is_none")]
     pub created: Option<String>,
     /// Whether user is a system administrator
     #[serde(rename = "sysadmin", skip_serializing_if = "Option::is_none")]
     pub sysadmin: Option<bool>,
+    /// Whether the account is active, deleted, or not yet activated.
     #[serde(rename = "state", skip_serializing_if = "Option::is_none")]
     pub state: Option<State>,
+    /// URL of the user's avatar, possibly relative to the site.
     #[serde(rename = "image_url", skip_serializing_if = "Option::is_none")]
     pub image_url: Option<String>,
+    /// Fully-qualified URL of the avatar, resolved by the portal.
+    ///
+    /// Prefer this over [`Self::image_url`] when fetching the image.
     #[serde(rename = "image_display_url", skip_serializing_if = "Option::is_none")]
     pub image_display_url: Option<String>,
     /// Number of packages created by this user
@@ -52,6 +67,8 @@ pub struct User {
 }
 
 impl User {
+    /// Create a [`User`] with the required `name`; every other field starts as
+    /// `None`.
     pub fn new(name: String) -> User {
         User {
             id: None,
@@ -69,15 +86,20 @@ impl User {
         }
     }
 }
+/// Whether a user account is live, deleted, or not yet activated.
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
 pub enum State {
+    /// The account is live.
     #[serde(rename = "active")]
     #[default]
     Active,
+    /// The account has been deleted. CKAN deletes softly, so the record is
+    /// still returned.
     #[serde(rename = "deleted")]
     Deleted,
+    /// The account exists but has not been activated.
     #[serde(rename = "inactive")]
     Inactive,
 }

--- a/data-gov-ckan/src/models/user_autocomplete.rs
+++ b/data-gov-ckan/src/models/user_autocomplete.rs
@@ -10,19 +10,28 @@
 
 use serde::{Deserialize, Serialize};
 
+/// One user suggestion from `user_autocomplete`.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UserAutocomplete {
+    /// Identifier of the suggested user.
+    ///
+    /// CKAN's `id` column is unconstrained text; see
+    /// [`crate::models::Package::id`] for why this is a `String`.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Username of the suggested user.
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// The user's full name, where they set one.
     #[serde(rename = "fullname", skip_serializing_if = "Option::is_none")]
     pub fullname: Option<String>,
+    /// The name the portal shows, falling back to the username.
     #[serde(rename = "display_name", skip_serializing_if = "Option::is_none")]
     pub display_name: Option<String>,
 }
 
 impl UserAutocomplete {
+    /// Create an empty [`UserAutocomplete`]; every field starts as `None`.
     pub fn new() -> UserAutocomplete {
         UserAutocomplete {
             id: None,

--- a/data-gov-ckan/src/models/validation_error_response.rs
+++ b/data-gov-ckan/src/models/validation_error_response.rs
@@ -11,17 +11,25 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// The envelope CKAN returns when an action fails validation.
+///
+/// Still HTTP 200, like every other Action API failure: [`Self::success`]
+/// is what marks it.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ValidationErrorResponse {
+    /// URL of the documentation for the action that was rejected.
     #[serde(rename = "help")]
     pub help: String,
+    /// Always `false` on this envelope.
     #[serde(rename = "success")]
     pub success: bool,
+    /// Which fields were rejected, and why.
     #[serde(rename = "error")]
     pub error: models::ValidationErrorResponseError,
 }
 
 impl ValidationErrorResponse {
+    /// Create a [`ValidationErrorResponse`] from its three members.
     pub fn new(
         help: String,
         success: bool,

--- a/data-gov-ckan/src/models/validation_error_response_error.rs
+++ b/data-gov-ckan/src/models/validation_error_response_error.rs
@@ -10,17 +10,27 @@
 
 use serde::{Deserialize, Serialize};
 
-/// ValidationErrorResponseError : Validation error details with field-specific messages
+/// The error object carried by a validation failure.
+///
+/// CKAN also sends one entry per rejected field alongside these two members,
+/// each holding an array of messages
+/// (`{"name": ["Missing value"], "__type": "Validation Error"}`). Those
+/// entries are not modelled here, because their names are the names of
+/// whatever fields the call got wrong; read them from
+/// [`crate::models::ActionResponse::error`], which keeps the raw JSON.
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ValidationErrorResponseError {
+    /// Always `Validation Error` on this object.
     #[serde(rename = "__type", skip_serializing_if = "Option::is_none")]
     pub __type: Option<Type>,
+    /// A summary message, where CKAN sends one.
     #[serde(rename = "message", skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
 }
 
 impl ValidationErrorResponseError {
-    /// Validation error details with field-specific messages
+    /// Create an empty [`ValidationErrorResponseError`]; every field starts
+    /// as `None`.
     pub fn new() -> ValidationErrorResponseError {
         ValidationErrorResponseError {
             __type: None,
@@ -28,10 +38,12 @@ impl ValidationErrorResponseError {
         }
     }
 }
+/// The single error type this object carries.
 #[derive(
     Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize,
 )]
 pub enum Type {
+    /// Serialized as `Validation Error`.
     #[serde(rename = "Validation Error")]
     #[default]
     ValidationError,

--- a/data-gov-ckan/src/models/vocabulary.rs
+++ b/data-gov-ckan/src/models/vocabulary.rs
@@ -11,6 +11,10 @@
 use crate::models;
 use serde::{Deserialize, Serialize};
 
+/// A controlled vocabulary that tags may belong to.
+///
+/// A tag naming a vocabulary is drawn from that list rather than being
+/// free-form - see [`crate::models::Tag::vocabulary_id`].
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Vocabulary {
     /// Unique identifier for the vocabulary.
@@ -19,13 +23,16 @@ pub struct Vocabulary {
     /// for why this is a `String` rather than a `uuid::Uuid`.
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
+    /// Name of the vocabulary.
     #[serde(rename = "name", skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// The tags this vocabulary contains.
     #[serde(rename = "tags", skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<models::Tag>>,
 }
 
 impl Vocabulary {
+    /// Create an empty [`Vocabulary`]; every field starts as `None`.
     pub fn new() -> Vocabulary {
         Vocabulary {
             id: None,


### PR DESCRIPTION
Closes out #118, the piece #59 deliberately deferred. `#![deny(missing_docs)]`
now covers all four crates.

## What was left

`data-gov-ckan` was the one crate #59 skipped: 173 undocumented public items
across 29 model files, the largest share of that work by far, in the crate
data.gov no longer uses. Holding the release for it was the wrong trade; doing
it now costs nothing.

| Crate | `#![deny(missing_docs)]` | Items documented |
|---|---|---|
| `data-gov-catalog` | yes (#59) | 60 |
| `data-gov` | yes (#59) | 40 |
| `data-gov-mcp-server` | yes (#59) | 0 - already clean |
| `data-gov-ckan` | **yes (this PR)** | **173** |

## What the docs say

The models mirror CKAN's schema, so most entries are one line. The ones worth
reading carry what a field name cannot:

- **`Group` models both groups and organizations**, and `is_organization` is
  the only thing separating them.
- **A failed action is still HTTP 200**, so `success` is what marks it, not the
  status code. Stated on `ActionResponse`, `ErrorResponse`, and
  `ValidationErrorResponse`.
- **A validation failure does not use `ErrorResponseError`.** It replaces
  `message` with one array of messages per rejected field, which is exactly why
  `ActionResponse::error` keeps raw JSON rather than that type - previously a
  comment on one field, now stated where a reader meets either type.
- **The utility API capitalises its members** and predates the v3 action API,
  which is why the autocomplete envelopes nest through `ResultSet` before
  reaching anything useful.
- **`StatusInfo::ckan_version` and `extensions`** together say which actions a
  deployment actually supports - the thing that endpoint is actually useful for.

`id` and `size` keep the notes explaining why they are `String` and `i64`
rather than `uuid::Uuid` and `i32` (#63, #62), so the docs cannot re-teach the
assumptions those two types got wrong. Verified in the diff, not assumed.

## Two mistakes the mechanical insertion made, both caught

Worth recording, because the first is the kind that ships.

**A doc landed inside a `compile_error!` body.** The inserter walks backwards
over an item's attribute block to find its insertion point, and counted the
macro's closing paren as an unclosed attribute, so it walked past the macro and
inserted into it:

```rust
compile_error!(
/// The HTTP client, its configuration, and its error type.
    "no TLS backend selected: ..."
);
pub mod client;
```

**This compiled clean.** The `cfg` guarding that macro is false whenever a TLS
feature is enabled, so the tokens were parsed and discarded. Nothing failed
except `missing_docs` still firing on `pub mod client;` - which is the only
reason it was found at all.

**The verifier written to catch that then produced 42 false failures.** It
compared the doc table's *first* line against the line abutting the item, which
for a multi-line doc is the *last* line. Every one of the 42 was the check
being wrong, not the code.

The corrected verifier re-runs the inserter's own declaration matching and
asserts each of the 173 docs sits directly above its intended item, with the
expected opening line and the expected line count:

```
verified 173 docs sit directly above their intended item
```

## Verification

- `just check` green: **617 tests**
- `cargo clippy -p data-gov-ckan --all-targets --all-features`: 0 errors with
  `missing_docs` denied
- **The deny was proved live**: added an undocumented `pub` item, confirmed the
  crate fails, removed it. A configured-but-inert lint would look identical to
  this PR.
- `#63`/`#62` notes confirmed still present on `Package::id` and
  `Resource::size` after the sweep

## Limits of what was checked

- This documents the **public** surface `missing_docs` covers. Private items
  and existing doc comments were left alone except for one generator
  placeholder (`/// ValidationErrorResponseError : Validation error details...`)
  which was replaced, since it named the type rather than describing it.
- Doc *accuracy* rests on CKAN's data model and this crate's own captured
  fixtures, not on a line-by-line re-probe of a live CKAN portal. Where a claim
  was specific enough to be wrong, it was written from the fixtures already in
  `data-gov-ckan/tests/fixtures/`.
- No behaviour changes. Docs, plus the crate-root `deny`.

Refs #118, #59