### PR TITLE
fix(download): remove an orphaned .part file when a transfer is dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -340,6 +340,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **A cancelled download no longer leaves its temporary file behind** (#125).
+  A transfer writes to a hidden `.data-gov-<pid>-<serial>.part` beside the
+  destination and renames it into place at the end. Every error path removed
+  that file before returning, but a cancelled download returns from none of
+  them: the future is dropped where it stands and no code in the function body
+  runs. The MCP server does exactly that on two deliberate paths - the
+  per-request timeout, and `notifications/cancelled` - and nothing anywhere
+  swept the leftovers, so a user who cancelled a few large downloads
+  accumulated hidden files in the download directory forever. The temporary
+  file is now owned by a guard whose `Drop` removes it, disarmed once the
+  rename onto the destination has succeeded. `std::process::exit` still skips
+  `Drop`, so a process that exits without unwinding can leave one.
 - **The CLI no longer panics when a reader closes the pipe early** (#115).
   `data-gov list organizations | head -5` died with exit 101 and a Rust
   backtrace note the moment `head` stopped reading, because `println!` panics

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -57,6 +57,63 @@ struct DownloadJob<'a> {
     allow_private_network: bool,
 }
 
+/// Owns the temporary file of a transfer in progress and removes it on drop.
+///
+/// `perform_download` discards its temporary file on every path it returns an
+/// error from, but a cancelled download returns from none of them: the future
+/// is dropped where it stands, and no code in the function body runs. The MCP
+/// server does exactly that on two deliberate paths - the per-request timeout,
+/// and `notifications/cancelled` - so without this a user who cancels a few
+/// large downloads accumulates hidden `.part` files in the download directory
+/// that nothing ever sweeps (#125).
+///
+/// Call [`PartialFileGuard::keep`] once the file has been renamed onto the
+/// destination, so a finished download does not have its own result removed.
+struct PartialFileGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl PartialFileGuard {
+    /// Take responsibility for removing `path` when this value is dropped.
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    /// The temporary path this guard is responsible for.
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Give up responsibility for the file: drop then removes nothing.
+    fn keep(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PartialFileGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        // A blocking unlink inside an async program, which the rest of this
+        // crate does not do. `Drop` cannot await, and the alternative -
+        // spawning a task to remove the file - loses the file whenever the
+        // runtime is already shutting down, which is one of the moments a
+        // cancelled download drops. One unlink syscall is short enough that
+        // holding the executor for it costs nothing measurable.
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {}
+            // Already gone: an error path discarded it before returning.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => eprintln!(
+                "data-gov: could not remove the unfinished download {}: {err}",
+                self.path.display()
+            ),
+        }
+    }
+}
+
 impl DataGovClient {
     /// Create a new DataGov client with default configuration.
     ///
@@ -683,8 +740,13 @@ impl DataGovClient {
         // The transfer goes to a temporary file beside the destination, so the
         // destination only ever holds a complete file. The two share a
         // directory because `rename` is atomic only within one filesystem.
-        let temp_path = Self::partial_path(output_dir);
-        let mut file = match File::create(&temp_path).await {
+        // The guard is armed before the file is opened, so the temporary file
+        // is owned by something that removes it from the moment it can exist.
+        // Every `return Err` below still discards it explicitly; the guard is
+        // the backstop for the way out that runs no code at all - the future
+        // being dropped mid-transfer (#125).
+        let partial = PartialFileGuard::new(Self::partial_path(output_dir));
+        let mut file = match File::create(partial.path()).await {
             Ok(file) => file,
             Err(err) => {
                 notify_failure(err.to_string(), &status_reporter);
@@ -705,14 +767,14 @@ impl DataGovClient {
             let chunk = match chunk_result {
                 Ok(chunk) => chunk,
                 Err(err) => {
-                    Self::discard_partial(&temp_path).await;
+                    Self::discard_partial(partial.path()).await;
                     notify_failure(err.to_string(), &status_reporter);
                     return Err(err.into());
                 }
             };
 
             if let Err(err) = file.write_all(&chunk).await {
-                Self::discard_partial(&temp_path).await;
+                Self::discard_partial(partial.path()).await;
                 notify_failure(err.to_string(), &status_reporter);
                 return Err(err.into());
             }
@@ -727,23 +789,27 @@ impl DataGovClient {
         // Dropping a `tokio::fs::File` does not flush it, so without this the
         // last chunk can be lost and the transfer still reported as complete.
         if let Err(err) = file.flush().await {
-            Self::discard_partial(&temp_path).await;
+            Self::discard_partial(partial.path()).await;
             notify_failure(err.to_string(), &status_reporter);
             return Err(err.into());
         }
         drop(file);
 
         if let Some(message) = Self::short_transfer(url, total_size, progress.downloaded_bytes) {
-            Self::discard_partial(&temp_path).await;
+            Self::discard_partial(partial.path()).await;
             notify_failure(message.clone(), &status_reporter);
             return Err(DataGovError::download_error(message));
         }
 
-        if let Err(err) = tokio::fs::rename(&temp_path, output_path).await {
-            Self::discard_partial(&temp_path).await;
+        if let Err(err) = tokio::fs::rename(partial.path(), output_path).await {
+            Self::discard_partial(partial.path()).await;
             notify_failure(err.to_string(), &status_reporter);
             return Err(err.into());
         }
+
+        // The transfer is now the destination file, so there is no temporary
+        // file left for the guard to remove.
+        partial.keep();
 
         if let Some(reporter) = status_reporter.as_ref() {
             let event = DownloadFinished {
@@ -1217,5 +1283,43 @@ mod tests {
         assert_eq!(DataGovClient::download_permits(0), 1);
         assert_eq!(DataGovClient::download_permits(1), 1);
         assert_eq!(DataGovClient::download_permits(5), 5);
+    }
+
+    #[test]
+    fn partial_file_guard_removes_the_file_when_it_is_dropped() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join(".data-gov-test.part");
+        std::fs::write(&path, b"an unfinished transfer").expect("seed");
+
+        drop(PartialFileGuard::new(path.clone()));
+
+        assert!(
+            !path.exists(),
+            "an armed guard must remove the temporary file it owns"
+        );
+    }
+
+    #[test]
+    fn partial_file_guard_keeps_the_file_once_it_has_been_disarmed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join(".data-gov-test.part");
+        std::fs::write(&path, b"a transfer that finished").expect("seed");
+
+        PartialFileGuard::new(path.clone()).keep();
+
+        assert!(
+            path.exists(),
+            "a disarmed guard must leave the file where a finished transfer put it"
+        );
+    }
+
+    #[test]
+    fn partial_file_guard_accepts_a_file_an_error_path_already_removed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let path = tmp.path().join(".data-gov-never-created.part");
+
+        // Every error path in `perform_download` discards the temporary file
+        // before returning, so the guard usually finds nothing to remove.
+        drop(PartialFileGuard::new(path));
     }
 }

--- a/data-gov/tests/download_integrity_tests.rs
+++ b/data-gov/tests/download_integrity_tests.rs
@@ -309,3 +309,115 @@ async fn a_stalled_transfer_is_still_cut_off() {
         "the stall must be cut off near the configured timeout, took {elapsed:?}"
     );
 }
+
+/// Watch `dir` until an entry appears in it, or `deadline` passes.
+///
+/// The dropped-transfer tests need this. Without it a run where the transfer
+/// never started would find an empty directory and pass while proving
+/// nothing, which is the one way those tests could go green for the wrong
+/// reason.
+async fn wait_for_first_entry(dir: std::path::PathBuf, deadline: Duration) -> bool {
+    let started = Instant::now();
+    while started.elapsed() < deadline {
+        if !entries(&dir).is_empty() {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    false
+}
+
+/// An origin that sends a little and then stalls, so the transfer is still
+/// running when the caller drops it. Returns the origin's base URL.
+async fn stalling_origin() -> String {
+    scripted_origin(
+        4096,
+        vec![
+            b"the first bytes and then a long wait".to_vec(),
+            b"never arrives".to_vec(),
+        ],
+        Duration::from_secs(30),
+    )
+    .await
+}
+
+/// A caller that cancels a download - an MCP request that times out, or a
+/// `notifications/cancelled` - drops the transfer future rather than returning
+/// through any of its error paths, so nothing in the function body runs.
+#[tokio::test]
+async fn a_dropped_transfer_leaves_no_temporary_file_behind() {
+    let tmp = TempDir::new().expect("tempdir");
+    let origin = stalling_origin().await;
+    // A ten second stall timeout, so the client's own timeout cannot fire
+    // first and take the error path this test is not about.
+    let client = client_for(tmp.path(), 10);
+    let dist = distribution(&format!("{origin}/report"), "report", "csv");
+
+    let watcher = tokio::spawn(wait_for_first_entry(
+        tmp.path().to_path_buf(),
+        Duration::from_secs(5),
+    ));
+
+    // The block bounds the timeout's own lifetime, so the transfer future is
+    // dropped before the assertions read the directory.
+    {
+        let download = client.download_distribution(&dist, Some(tmp.path()));
+        tokio::time::timeout(Duration::from_secs(1), download)
+            .await
+            .expect_err("the stalled transfer must still be running when it is dropped");
+    }
+
+    assert!(
+        watcher.await.expect("watcher task"),
+        "the transfer never reached the point of creating a file, so this run proves nothing"
+    );
+    assert_eq!(
+        entries(tmp.path()),
+        Vec::<String>::new(),
+        "a dropped transfer must not leave its temporary file behind"
+    );
+}
+
+/// Cancel, then retry: the second attempt must land, and the first must not
+/// still be sitting in the directory beside it.
+#[tokio::test]
+async fn a_download_retried_after_a_cancelled_one_leaves_only_the_destination() {
+    let tmp = TempDir::new().expect("tempdir");
+    let stalled = stalling_origin().await;
+    let client = client_for(tmp.path(), 10);
+    let cancelled = distribution(&format!("{stalled}/report"), "report", "csv");
+
+    let watcher = tokio::spawn(wait_for_first_entry(
+        tmp.path().to_path_buf(),
+        Duration::from_secs(5),
+    ));
+    {
+        let download = client.download_distribution(&cancelled, Some(tmp.path()));
+        tokio::time::timeout(Duration::from_secs(1), download)
+            .await
+            .expect_err("the stalled transfer must still be running when it is dropped");
+    }
+    assert!(
+        watcher.await.expect("watcher task"),
+        "the cancelled transfer never created a file, so this run proves nothing"
+    );
+
+    let body = b"a complete body".to_vec();
+    let whole = scripted_origin(body.len(), vec![body.clone()], Duration::ZERO).await;
+    let dist = distribution(&format!("{whole}/report"), "report", "csv");
+    let written = client
+        .download_distribution(&dist, Some(tmp.path()))
+        .await
+        .expect("the retry must land");
+
+    assert_eq!(
+        tokio::fs::read(&written).await.expect("read back"),
+        body,
+        "the retry must hold the whole body"
+    );
+    assert_eq!(
+        entries(tmp.path()),
+        vec!["report.csv".to_string()],
+        "the cancelled transfer's temporary file must not outlive it"
+    );
+}


### PR DESCRIPTION
Fixes a behaviour defect confirmed by adversarial verification during the 0.5.0 release review, then independently reviewed from a fresh context.

Gate green in the authoring worktree; the reviewer re-ran it on a clean checkout.

Full detail is in the commit body: what changed, the tests added, and the mutation run to prove each test can fail.

Part of the 0.5.0 release-review sweep.