### PR TITLE
fix(mcp): stop an empty format filter deleting every distribution, and check path components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -377,6 +377,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`unavailableFormats` names the right format** (#70). A `.filter()` dropped
   blank entries, so the vector no longer index-aligned with the one it was
   zipped against and the report paired the wrong strings.
+- **A `formats` filter that names no format downloads everything again.**
+  `"formats": []`, `["  "]`, or any array whose entries are all blank left an
+  empty filter list, and retaining on an empty list cleared every
+  distribution. The tool then answered `isError: true` with "no matching
+  downloadable distributions" and an empty `unavailableFormats`, naming no
+  format the model could correct - a dead end for an agent, which is the only
+  caller this server has. A filter that matches everything now means the same
+  as no filter at all.
+- **`outputDir` accepts a directory whose name contains dots.** The guard was
+  a substring test for `..`, so `/data/v1..v2/exports` and
+  `/srv/archive..2024` were refused with "output_dir must not contain '..'
+  path components", which was not true of either path. It now reads path
+  components, the same reading `data_gov::util::join_inside` takes of the
+  component it joins on. Every traversal is still refused, including a
+  backslash-separated one on a host whose separator is `/`.
 - **An interrupted download no longer destroys the file it was replacing** (#49).
   `File::create` is create-plus-truncate, so an existing complete file was zeroed
   the moment the request succeeded, and every error path left a partial file

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -1103,3 +1103,139 @@ async fn a_download_where_some_files_arrived_reports_is_error_false() {
         "the partial failure must still be visible in the payload: {summary}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// A format filter that names no format
+// ---------------------------------------------------------------------------
+
+/// A dataset with one distribution the mock server actually serves.
+///
+/// The `formats` tests need a download that can succeed, so the failure they
+/// report can only come from the filter.
+fn one_csv_dataset(slug: &str, mock_uri: &str) -> Value {
+    json!({
+        "results": [{
+            "slug": slug,
+            "title": "One CSV",
+            "dcat": {
+                "@type": "dcat:Dataset",
+                "title": "One CSV",
+                "distribution": [{
+                    "@type": "dcat:Distribution",
+                    "title": "readings",
+                    "downloadURL": format!("{mock_uri}/readings.csv"),
+                    "mediaType": "text/csv"
+                }]
+            }
+        }],
+        "sort": "relevance"
+    })
+}
+
+/// Dispatch `data_gov_download_resources` for `one_csv_dataset` with the given
+/// `formats` argument, and return the tool result.
+async fn download_with_formats(scratch: &str, formats: Value) -> Value {
+    let mock = MockServer::start().await;
+    let slug = "one-csv";
+    Mock::given(wm_method("GET"))
+        .and(wm_path(format!("/api/dataset/{slug}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(one_csv_dataset(slug, &mock.uri())))
+        .mount(&mock)
+        .await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/readings.csv"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("a,b\n1,2\n"))
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+    let output_dir = scratch_dir(scratch);
+
+    let value = server
+        .dispatch(
+            "tools/call",
+            Some(json!({
+                "name": "data_gov_download_resources",
+                "arguments": {
+                    "datasetId": slug,
+                    "formats": formats,
+                    "outputDir": output_dir.to_string_lossy(),
+                    "datasetSubdirectory": false
+                }
+            })),
+        )
+        .await
+        .expect("a download is a tool result, not a JSON-RPC error");
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+    value
+}
+
+/// An empty `formats` array names no format to keep out, so it keeps
+/// everything - the same as omitting the argument.
+///
+/// Filtering on it instead removed every distribution and reported "no
+/// matching downloadable distributions" with an empty `unavailableFormats`,
+/// naming no format the model could correct.
+#[tokio::test]
+async fn an_empty_formats_array_downloads_every_distribution() {
+    let value = download_with_formats("empty-formats", json!([])).await;
+
+    assert!(
+        !tool_error_flag(&value),
+        "an empty filter names no format to exclude: {value}"
+    );
+    let summary = &value["structuredContent"];
+    assert_eq!(summary["successfulCount"], json!(1), "{summary}");
+    assert_eq!(summary["failedCount"], json!(0), "{summary}");
+}
+
+/// Blank entries are dropped because each would match every distribution, so
+/// an array of nothing but blanks is a filter that matches everything.
+#[tokio::test]
+async fn a_formats_array_of_only_blanks_downloads_every_distribution() {
+    let value = download_with_formats("blank-formats", json!(["", "  ", "\t"])).await;
+
+    assert!(
+        !tool_error_flag(&value),
+        "every entry matches everything, so the filter excludes nothing: {value}"
+    );
+    let summary = &value["structuredContent"];
+    assert_eq!(summary["successfulCount"], json!(1), "{summary}");
+    assert_eq!(summary["failedCount"], json!(0), "{summary}");
+}
+
+/// The other half: a filter that does name a format still filters. Without
+/// this, "keep everything when the list is empty" could be written as "keep
+/// everything", and both tests above would still pass.
+#[tokio::test]
+async fn a_format_filter_that_names_a_format_still_excludes_the_rest() {
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/api/dataset/csv-only"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(csv_only_dataset("csv-only")))
+        .mount(&mock)
+        .await;
+
+    let server = test_server(&mock.uri());
+
+    let value = server
+        .dispatch(
+            "tools/call",
+            Some(json!({
+                "name": "data_gov_download_resources",
+                "arguments": {"datasetId": "csv-only", "formats": ["", "XLSX"]}
+            })),
+        )
+        .await
+        .expect("nothing matched, which is an outcome rather than a fault");
+
+    assert!(
+        tool_error_flag(&value),
+        "XLSX matches no distribution, so nothing is left to download: {value}"
+    );
+    assert!(
+        tool_text(&value).contains("XLSX"),
+        "the model needs to be told which format was unavailable: {value}"
+    );
+}

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -4,7 +4,7 @@ use data_gov::DataGovClient;
 use data_gov::catalog::models::{Distribution, SearchHit};
 use serde_json::{Value, json};
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use tokio::time::timeout;
 
 use crate::server::DataGovMcpServer;
@@ -285,29 +285,37 @@ impl DataGovMcpServer {
             // match every distribution.
             let filters = normalized_format_filters(formats);
 
-            let distribution_matches = |d: &Distribution, filter: &str| -> bool {
-                d.format
-                    .as_deref()
-                    .is_some_and(|f| f.to_ascii_lowercase().contains(filter))
-                    || d.media_type
+            // A filter list that reduces to nothing matches every
+            // distribution, so it means the same as no filter at all: an
+            // empty array, or one holding only blanks. Retaining on it
+            // instead cleared the list, and the caller was told nothing
+            // matched without being told which format to try, because there
+            // was no format to name.
+            if !filters.is_empty() {
+                let distribution_matches = |d: &Distribution, filter: &str| -> bool {
+                    d.format
                         .as_deref()
-                        .is_some_and(|m| m.to_ascii_lowercase().contains(filter))
-            };
+                        .is_some_and(|f| f.to_ascii_lowercase().contains(filter))
+                        || d.media_type
+                            .as_deref()
+                            .is_some_and(|m| m.to_ascii_lowercase().contains(filter))
+                };
 
-            for (raw, normalized) in &filters {
-                if !distributions
-                    .iter()
-                    .any(|d| distribution_matches(d, normalized))
-                {
-                    unavailable_formats.push(raw.clone());
+                for (raw, normalized) in &filters {
+                    if !distributions
+                        .iter()
+                        .any(|d| distribution_matches(d, normalized))
+                    {
+                        unavailable_formats.push(raw.clone());
+                    }
                 }
-            }
 
-            distributions.retain(|d| {
-                filters
-                    .iter()
-                    .any(|(_, normalized)| distribution_matches(d, normalized))
-            });
+                distributions.retain(|d| {
+                    filters
+                        .iter()
+                        .any(|(_, normalized)| distribution_matches(d, normalized))
+                });
+            }
         }
 
         if distributions.is_empty() {
@@ -574,7 +582,7 @@ pub(crate) fn resolve_output_dir(
     let base = match requested {
         None => default_base.to_path_buf(),
         Some(dir) => {
-            if dir.contains("..") {
+            if names_a_parent_directory(dir) {
                 return Err(ServerError::InvalidParams(
                     "output_dir must not contain '..' path components".to_string(),
                 ));
@@ -606,6 +614,24 @@ fn dataset_subdirectory(base: &Path, safe_dataset_slug: &str) -> Result<PathBuf,
         ServerError::InvalidParams(format!(
             "dataset slug does not name a directory inside the chosen download directory: {err}"
         ))
+    })
+}
+
+/// True when `dir` carries a parent-directory step.
+///
+/// Reads path components rather than searching for the two characters, so a
+/// name that merely contains dots - `/data/v1..v2/exports` - is the ordinary
+/// directory it looks like and not a traversal. This is the same reading
+/// [`data_gov::util::join_inside`] takes of the component it joins on.
+///
+/// Backslash-separated segments are read too. On a host whose separator is
+/// `/`, `..\\escape` is one ordinary component and would otherwise pass, and
+/// the caller of an MCP server is free to be a Windows client.
+fn names_a_parent_directory(dir: &str) -> bool {
+    dir.split('\\').any(|segment| {
+        Path::new(segment)
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
     })
 }
 
@@ -657,6 +683,37 @@ mod tests {
         )
         .expect_err("'..' inside backslash path must be rejected");
         assert!(matches!(err, ServerError::InvalidParams(_)));
+    }
+
+    /// Dots in a directory name are not a parent-directory step.
+    /// `/data/v1..v2/exports` names an ordinary directory, and refusing it on
+    /// the substring `..` both blocks a legitimate path and tells the caller
+    /// something about it that is not true.
+    #[test]
+    fn resolve_output_dir_accepts_a_directory_name_that_contains_dots() {
+        for dir in [
+            "/data/v1..v2/exports",
+            "/srv/archive..2024",
+            "/tmp/..hidden",
+        ] {
+            let resolved = resolve_output_dir(Some(dir), false, "slug", default_base())
+                .unwrap_or_else(|err| panic!("{dir} has no `..` component, got: {err:?}"));
+            assert_eq!(resolved, PathBuf::from(dir));
+        }
+    }
+
+    /// The other half: dots in a name buy a real traversal nothing. The check
+    /// reads path components, so a `..` step beside such a name is still
+    /// refused - under either separator.
+    #[test]
+    fn resolve_output_dir_rejects_traversal_beside_a_name_that_contains_dots() {
+        for dir in ["/data/v1..v2/../escape", "/srv/a..b/..", "..\\v1..v2"] {
+            let outcome = resolve_output_dir(Some(dir), false, "slug", default_base());
+            assert!(
+                matches!(outcome, Err(ServerError::InvalidParams(_))),
+                "{dir} leaves its parent and must be refused, got: {outcome:?}"
+            );
+        }
     }
 
     /// The `..` check covers the string the caller supplied. The slug is joined


### PR DESCRIPTION
Fixes a behaviour defect confirmed by adversarial verification during the 0.5.0 release review, then independently reviewed from a fresh context.

Gate green in the authoring worktree; the reviewer re-ran it on a clean checkout.

Full detail is in the commit body: what changed, the tests added, and the mutation run to prove each test can fail.

Part of the 0.5.0 release-review sweep.