### PR TITLE
fix(catalog,ckan): make the client-construction panic name its cause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `Error::downcast_mut()`.
 
 ### Added
+- **Fallible client construction: `Configuration::try_new` and
+  `Configuration::try_with_timeouts`**, on both `data-gov-catalog` and
+  `data-gov-ckan`. `new`, `default`, and `with_timeouts` cannot report a
+  failure to build an HTTP client, because they have no `Result` to propagate
+  through; these return it as `RequestError` instead, so a consumer that must
+  not take a panic from a library can report the cause and exit. Additive: the
+  existing constructors keep their signatures.
 - **`data-gov-ckan`'s models are documented** (#118). Every public item in the
   crate now carries a doc comment: what each CKAN concept is, and the things
   that are not guessable from a field name - that `Group` models both groups
@@ -340,6 +347,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **A failure to build the HTTP client now names its cause instead of
+  reqwest's `Client::new()`.** Both client crates fell back to
+  `reqwest::Client::new()` / `Client::default()` when `ClientBuilder::build()`
+  failed, documented as the option that "does not turn a working call into a
+  panic". It is not: verified against reqwest 0.13.4,
+  `<reqwest::Client as Default>::default()` calls `Client::new()`, which is
+  `ClientBuilder::new().build().expect("Client::new()")` - so on a host whose
+  TLS backend will not start, the fallback hits the same error and panics with
+  the bare text `Client::new()`, naming neither the crate nor the cause. Worse,
+  for a build failure reqwest's own default does not share, the fallback
+  silently returned a client with **no timeouts at all**, undoing the timeouts
+  the call had just asked for (#48). There is no non-panicking fallback to
+  have: if no client can be built, none can be built. The panic now names the
+  crate, the causes to look at (TLS backend, proxy, DNS resolver), and the
+  fallible constructor that returns the failure as an error instead.
+- **`dataset_by_slug` documents that it resolves slugs, not the `_id` half of
+  `{slug_or_id}`.** The endpoint does accept an OpenSearch document id and
+  answers 200 with the correct dataset, but its response carries no copy of
+  the id it was asked for - `_sort` arrives null on that endpoint - so nothing
+  in the body can show the dataset is the one the caller named. The wrapper
+  keeps returning `None` rather than an unverified hit (#94), and now says so,
+  with the reason and the way round it: use the `slug` from the `/search` hit
+  the id came from. A fixture captured from a live document-id lookup pins
+  that the id really is absent, so the day the API starts returning it, the
+  test fails and the restriction can be lifted.
 - **The CLI no longer panics when a reader closes the pipe early** (#115).
   `data-gov list organizations | head -5` died with exit 101 and a Rust
   backtrace note the moment `head` stopped reading, because `println!` panics

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -19,19 +19,66 @@ pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// documented posture and the shipped default agree.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Build a [`reqwest::Client`] with an explicit connect and overall timeout.
-///
-/// Falls back to [`reqwest::Client::new`] (no timeout at all) only if the
-/// builder itself fails. In practice that happens for a TLS backend
-/// misconfiguration, never for a timeout value -- but [`Default::default`]
-/// has no `Result` to propagate through, so a fallback is the only option
-/// that does not turn a working call into a panic.
-fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
+/// The builder every client in this module is finished from.
+fn client_builder(connect_timeout: Duration, timeout: Duration) -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .connect_timeout(connect_timeout)
         .timeout(timeout)
+}
+
+/// Finish a [`reqwest::ClientBuilder`], reporting a build failure as an error.
+///
+/// # Errors
+///
+/// [`CatalogError::RequestError`], carrying reqwest's own message, when no
+/// client can be constructed. In reqwest 0.13 `ClientBuilder::build` fails
+/// only for TLS backend, proxy, or DNS resolver setup -- never for a timeout
+/// value.
+fn try_finish_client(builder: reqwest::ClientBuilder) -> Result<reqwest::Client, CatalogError> {
+    builder
         .build()
-        .unwrap_or_default()
+        .map_err(|e| CatalogError::RequestError(Box::new(e)))
+}
+
+/// Finish a [`reqwest::ClientBuilder`] for a constructor that has no `Result`
+/// to propagate through.
+///
+/// There is deliberately no fallback client. `reqwest::Client::new` and
+/// `<reqwest::Client as Default>::default` both call `ClientBuilder::build`
+/// and `expect` its result, so on a host whose TLS backend, proxy, or DNS
+/// resolver cannot be set up they fail exactly as this call did -- and panic
+/// with the bare text `Client::new()`, which names neither the crate nor the
+/// cause. A fallback would therefore not avoid the panic; it would only hide
+/// where it came from. Worse, for a build failure reqwest's own default does
+/// not share, it silently returns a client with no timeouts at all.
+///
+/// # Panics
+///
+/// When reqwest cannot construct a client at all. [`Configuration::try_new`]
+/// and [`Configuration::try_with_timeouts`] return that failure as a
+/// [`CatalogError`] instead.
+fn finish_client(builder: reqwest::ClientBuilder) -> reqwest::Client {
+    match builder.build() {
+        Ok(client) => client,
+        Err(e) => panic!(
+            "data-gov-catalog: no HTTP client could be constructed. reqwest's \
+             client builder failed, which happens for TLS backend, proxy, or \
+             DNS resolver setup - never for a timeout value. \
+             reqwest::Client::new() fails the same way, so there is no \
+             fallback client to return. Use Configuration::try_new or \
+             Configuration::try_with_timeouts to handle this as an error. \
+             Cause: {e}"
+        ),
+    }
+}
+
+/// Build a [`reqwest::Client`] with an explicit connect and overall timeout.
+///
+/// # Panics
+///
+/// See [`finish_client`].
+fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
+    finish_client(client_builder(connect_timeout, timeout))
 }
 
 /// Configuration for the Catalog API client.
@@ -58,9 +105,72 @@ pub struct Configuration {
 }
 
 impl Configuration {
+    /// Assemble a [`Configuration`] around an already-built client.
+    ///
+    /// Every constructor funnels through here so the default `base_path` and
+    /// `user_agent` are written once, and so the fallible constructors never
+    /// reach [`Default::default`] -- which builds a client of its own, and
+    /// panics if it cannot.
+    fn with_client(client: reqwest::Client) -> Self {
+        Self {
+            base_path: "https://catalog.data.gov".to_owned(),
+            user_agent: Some(concat!("data-gov-rs/", env!("CARGO_PKG_VERSION")).to_owned()),
+            client,
+        }
+    }
+
     /// Build a [`Configuration`] with default values.
+    ///
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all -- a TLS backend,
+    /// proxy, or DNS resolver that will not start. Nothing can be returned in
+    /// that case: `reqwest::Client::new` fails the same way. Use
+    /// [`Configuration::try_new`] to receive it as an error instead.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Build a [`Configuration`] with default values, reporting a client
+    /// construction failure instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// [`CatalogError::RequestError`] when reqwest cannot construct an HTTP
+    /// client: TLS backend, proxy, or DNS resolver setup. There is no
+    /// degraded client to fall back to, so a consumer that must not panic
+    /// should report this and stop.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use data_gov_catalog::Configuration;
+    ///
+    /// let config = Configuration::try_new()?;
+    /// assert_eq!(config.base_path, "https://catalog.data.gov");
+    /// # Ok::<(), data_gov_catalog::CatalogError>(())
+    /// ```
+    pub fn try_new() -> Result<Self, CatalogError> {
+        Self::try_with_timeouts(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT)
+    }
+
+    /// Build a [`Configuration`] with the given timeouts, reporting a client
+    /// construction failure instead of panicking.
+    ///
+    /// The fallible counterpart of [`Configuration::with_timeouts`].
+    ///
+    /// # Errors
+    ///
+    /// [`CatalogError::RequestError`] when reqwest cannot construct an HTTP
+    /// client. Timeout values themselves are never rejected.
+    pub fn try_with_timeouts(
+        connect_timeout: Duration,
+        timeout: Duration,
+    ) -> Result<Self, CatalogError> {
+        Ok(Self::with_client(try_finish_client(client_builder(
+            connect_timeout,
+            timeout,
+        ))?))
     }
 
     /// Build a [`Configuration`] whose client uses the given timeouts
@@ -80,21 +190,25 @@ impl Configuration {
     ///     Duration::from_secs(15),
     /// );
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all. See
+    /// [`Configuration::new`]; [`Configuration::try_with_timeouts`] returns
+    /// that failure as an error.
     pub fn with_timeouts(connect_timeout: Duration, timeout: Duration) -> Self {
-        Self {
-            client: build_client(connect_timeout, timeout),
-            ..Self::default()
-        }
+        Self::with_client(build_client(connect_timeout, timeout))
     }
 }
 
 impl Default for Configuration {
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all. See
+    /// [`Configuration::new`], whose [`Configuration::try_new`] counterpart
+    /// returns that failure as an error.
     fn default() -> Self {
-        Self {
-            base_path: "https://catalog.data.gov".to_owned(),
-            user_agent: Some(concat!("data-gov-rs/", env!("CARGO_PKG_VERSION")).to_owned()),
-            client: build_client(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT),
-        }
+        Self::with_client(build_client(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT))
     }
 }
 
@@ -583,6 +697,20 @@ impl CatalogClient {
     /// the endpoint does no prefix or substring matching, so a near-miss slug
     /// returns 404 rather than a plausible wrong dataset.
     ///
+    /// **Slugs only, though the endpoint takes more.** The `_id` half of
+    /// `{slug_or_id}` is the OpenSearch document id, the third element of a
+    /// hit's `_sort` array on `/search`. The endpoint resolves one and answers
+    /// 200 with the right dataset, but this call still returns `Ok(None)` for
+    /// it: the response carries no copy of the id it was asked for -- `_sort`
+    /// arrives null on this endpoint -- so nothing in the body can show the
+    /// dataset is the one the caller named. Returning it would mean trusting
+    /// the server's match unverified, which is what the slug comparison below
+    /// exists to prevent. Nothing else resolves at all: the harvest_record
+    /// UUID, the CKAN id, and the DCAT `identifier` each 404.
+    ///
+    /// To go from a document id to a dataset, take the `slug` from the
+    /// `/search` hit the id came from and pass that instead.
+    ///
     /// # Errors
     ///
     /// Returns [`CatalogError::ApiError`] for any non-2xx status other than
@@ -597,10 +725,12 @@ impl CatalogClient {
         let path = format!("/api/dataset/{}", encode_path_segment(slug)?);
         let response: Option<models::SearchResponse> = self.get_json_optional(&path).await?;
 
-        // Belt and braces: the endpoint is exact, but a hit whose slug differs
-        // from the request would mean the server matched something else, and
-        // returning it would be the silent-wrong-dataset failure this call
-        // exists to avoid.
+        // The slug is the only thing in the response that can be checked
+        // against what was asked for, so a hit whose slug differs is a hit
+        // this call cannot attribute to the request -- either the server
+        // matched something else, or the caller passed a document id, and the
+        // body cannot tell the two apart. Returning it either way would be the
+        // silent-wrong-dataset failure this call exists to avoid.
         Ok(response
             .and_then(|r| r.results.into_iter().next())
             .filter(|hit| hit.slug.as_deref() == Some(slug)))
@@ -786,5 +916,73 @@ mod tests {
 
         let new_config = Configuration::new();
         assert_eq!(new_config.base_path, default_config.base_path);
+    }
+
+    /// A builder that cannot be built, so the no-client-at-all paths can be
+    /// exercised on a host whose TLS backend works.
+    ///
+    /// `\n` is not a legal header value, so `ClientBuilder::user_agent`
+    /// stores the error and `build()` returns it. That is the same `Err` a
+    /// TLS backend failure produces, and it is the only one reachable from a
+    /// test: this crate's builder sets nothing but timeouts, and a timeout
+    /// value cannot fail.
+    fn unbuildable_client() -> reqwest::ClientBuilder {
+        reqwest::Client::builder().user_agent("\n")
+    }
+
+    /// When reqwest can build no client, neither can this crate: `Client::new`
+    /// and `Client::default` call the same failing builder. The panic is
+    /// therefore unavoidable, and what the caller reads must name the crate,
+    /// the causes to look at, and the fallible constructor that returns the
+    /// failure instead -- not reqwest's bare `Client::new()`, and never a
+    /// silently substituted client with no timeouts.
+    #[test]
+    fn client_construction_failure_panics_with_a_message_naming_the_cause() {
+        let payload = std::panic::catch_unwind(|| finish_client(unbuildable_client()))
+            .expect_err("a builder that cannot build must not yield a client");
+        let message = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&str>().copied())
+            .unwrap_or("<non-string panic payload>");
+
+        for expected in ["data-gov-catalog", "TLS", "try_new"] {
+            assert!(
+                message.contains(expected),
+                "panic message must name {expected:?}, got {message:?}"
+            );
+        }
+    }
+
+    /// The fallible constructors exist so a consumer can report the failure
+    /// and exit cleanly rather than take a panic from a library.
+    #[test]
+    fn try_finish_client_reports_a_construction_failure_as_a_request_error() {
+        let error = try_finish_client(unbuildable_client())
+            .expect_err("a builder that cannot build must fail");
+
+        assert!(
+            matches!(error, CatalogError::RequestError(_)),
+            "expected RequestError, got {error:?}"
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.len() > "Request error: ".len(),
+            "the error must carry reqwest's own reason, got {rendered:?}"
+        );
+    }
+
+    /// On a host that can build a client at all, the fallible constructors
+    /// return the same configuration as the panicking ones.
+    #[test]
+    fn try_new_and_try_with_timeouts_return_the_documented_defaults() {
+        let config = Configuration::try_new().expect("a client builds on this host");
+        assert_eq!(config.base_path, Configuration::new().base_path);
+        assert_eq!(config.user_agent, Configuration::new().user_agent);
+
+        let timed =
+            Configuration::try_with_timeouts(Duration::from_secs(1), Duration::from_secs(2))
+                .expect("a client builds on this host");
+        assert_eq!(timed.base_path, config.base_path);
     }
 }

--- a/data-gov-catalog/src/models.rs
+++ b/data-gov-catalog/src/models.rs
@@ -97,6 +97,11 @@ pub struct SearchHit {
     #[serde(default, rename = "_score", skip_serializing_if = "Option::is_none")]
     pub score: Option<f64>,
     /// Cursor components that generated this hit's position.
+    ///
+    /// An array whose third element is the OpenSearch document id of this
+    /// hit. `/api/dataset/{slug_or_id}` resolves that id, but answers with
+    /// `_sort` null, so a hit fetched by exact lookup never carries one --
+    /// see [`CatalogClient::dataset_by_slug`](crate::CatalogClient::dataset_by_slug).
     #[serde(default, rename = "_sort", skip_serializing_if = "Option::is_none")]
     pub sort_key: Option<Value>,
 }

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -17,6 +17,24 @@ fn fixture(name: &str) -> String {
     std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("fixture {path} missing: {e}"))
 }
 
+/// The last path segment of the endpoint a fixture was captured from.
+///
+/// An OpenSearch document id is re-indexed on harvest, so the capture script
+/// discovers it rather than pinning it, and `MANIFEST.json` records the value
+/// it used. Reading the request back out of the manifest keeps a test asking
+/// for the exact id that produced the body it serves.
+fn captured_path_tail(fixture_name: &str) -> String {
+    let manifest: serde_json::Value =
+        serde_json::from_str(&fixture("MANIFEST.json")).expect("MANIFEST.json parses");
+    manifest["fixtures"][fixture_name]["endpoint"]
+        .as_str()
+        .unwrap_or_else(|| panic!("MANIFEST.json records no endpoint for {fixture_name}"))
+        .rsplit('/')
+        .next()
+        .expect("an endpoint path has at least one segment")
+        .to_owned()
+}
+
 fn client_for(server: &MockServer) -> CatalogClient {
     CatalogClient::new(Arc::new(Configuration {
         base_path: server.uri(),
@@ -370,6 +388,37 @@ async fn dataset_by_slug_returns_none_when_the_hit_has_a_different_slug() {
     assert!(
         result.is_none(),
         "a hit whose slug differs from the request must not be returned, got {result:?}"
+    );
+}
+
+/// `/api/dataset/{slug_or_id}` resolves an OpenSearch document id as well as a
+/// slug: this fixture is the live 200 it answered a document id with, carrying
+/// the correct dataset. The wrapper still returns `None`, and deliberately.
+/// The response contains no copy of the id that was asked for -- asserted by
+/// `fixture_parity_tests::exact_lookup_by_document_id_returns_the_dataset_without_echoing_the_id`
+/// -- so nothing in it can show the dataset is the one the caller named, and
+/// handing it back would be the unverified hit the slug check exists to stop.
+#[tokio::test]
+async fn dataset_by_slug_returns_none_for_a_document_id_it_cannot_verify() {
+    let document_id = captured_path_tail("dataset_by_document_id.json");
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("/api/dataset/{document_id}")))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw(fixture("dataset_by_document_id.json"), "application/json"),
+        )
+        .mount(&server)
+        .await;
+
+    let result = client_for(&server)
+        .dataset_by_slug(&document_id)
+        .await
+        .expect("the lookup itself succeeds: the server answered 200");
+
+    assert!(
+        result.is_none(),
+        "a hit the request cannot be shown to identify must not be returned, got {result:?}"
     );
 }
 

--- a/data-gov-catalog/tests/fixture_parity_tests.rs
+++ b/data-gov-catalog/tests/fixture_parity_tests.rs
@@ -215,6 +215,62 @@ fn contact_point_name_survives_deserialization() {
     );
 }
 
+/// Why [`data_gov_catalog::CatalogClient::dataset_by_slug`] resolves slugs
+/// only, though the endpoint behind it is `/api/dataset/{slug_or_id}`.
+///
+/// The endpoint does accept an OpenSearch document id -- the third element of
+/// a `/search` hit's `_sort` array -- and answers 200 with the right dataset.
+/// This capture is that answer. What it does not contain is the id that was
+/// asked for: `_sort` arrives null on this endpoint, and the id appears
+/// nowhere else in the body. Nothing in the response can therefore show the
+/// dataset is the one the caller named, so the wrapper returns `None` rather
+/// than a hit it cannot attribute to the request.
+///
+/// When this test fails because `_sort` now arrives populated, that reason has
+/// expired: compare the requested value against `sort_key[2]` and accept the
+/// hit when they match, alongside the existing slug comparison.
+#[test]
+fn exact_lookup_by_document_id_returns_the_dataset_without_echoing_the_id() {
+    let name = "dataset_by_document_id.json";
+    let endpoint = manifest()["fixtures"][name]["endpoint"]
+        .as_str()
+        .unwrap_or_else(|| panic!("MANIFEST.json records no endpoint for {name}"))
+        .to_owned();
+    let document_id = endpoint
+        .rsplit('/')
+        .next()
+        .expect("an endpoint path has at least one segment");
+
+    let response: models::SearchResponse = parse(name);
+    let hit = response
+        .results
+        .first()
+        .expect("the capture must carry the dataset the id resolved to");
+
+    assert_ne!(
+        hit.slug.as_deref(),
+        Some(document_id),
+        "the capture must be a lookup by document id, not by slug"
+    );
+    assert!(
+        hit.dcat.is_some(),
+        "the server really did answer with the dataset, so what the wrapper \
+         drops is a correct record, not an empty one"
+    );
+    assert!(
+        hit.sort_key.is_none(),
+        "`_sort` now arrives on the exact-lookup endpoint: {:?}. The document \
+         id can be verified from the response, so dataset_by_slug can accept \
+         one.",
+        hit.sort_key
+    );
+    assert!(
+        !fixture(name).contains(document_id),
+        "the requested document id {document_id} appears in the response body: \
+         dataset_by_slug can verify a document-id lookup after all"
+    );
+}
+
 // --- Fixture provenance -----------------------------------------------------
 //
 // A fixture with no recorded origin is indistinguishable from one somebody

--- a/data-gov-catalog/tests/fixtures/MANIFEST.json
+++ b/data-gov-catalog/tests/fixtures/MANIFEST.json
@@ -1,5 +1,11 @@
 {
   "fixtures": {
+    "dataset_by_document_id.json": {
+      "endpoint": "/api/dataset/488e78de-3a7f-4b2c-8975-81817dcc8dfe",
+      "status": 200,
+      "source": "https://catalog.data.gov",
+      "captured": "2026-08-16"
+    },
     "dataset_by_slug.json": {
       "endpoint": "/api/dataset/crime-data-from-2020-to-present",
       "status": 200,

--- a/data-gov-catalog/tests/fixtures/dataset_by_document_id.json
+++ b/data-gov-catalog/tests/fixtures/dataset_by_document_id.json
@@ -1,0 +1,100 @@
+{
+  "aggregations": null,
+  "results": [
+    {
+      "_score": 0.0,
+      "_sort": null,
+      "dcat": {
+        "@type": "dcat:Dataset",
+        "accessLevel": "public",
+        "contactPoint": {
+          "@type": "vcard:Contact",
+          "fn": "LAPD OpenData",
+          "hasEmail": "mailto:no-reply@data.lacity.org"
+        },
+        "description": "******Notice: Transition to NIBRS-Compliant Crime Data Reporting\nThe Los Angeles Police Department (LAPD) has completed its transition from the legacy Records Management System, which reported crime and arrest data under Uniform Crime Reporting (UCR) standards, to a modernized system fully aligned with the National Incident-Based Reporting System (NIBRS).\nAs part of this transition, the legacy system is no longer active, and no new information will be entered. Consequently, the Crime Data from 2020 to Present dataset will no longer be updated. It will remain available on the portal for historical reference only.\nTo provide the public with current and comprehensive information, LAPD now publishes datasets sourced directly from the new Records Management System in accordance with NIBRS standards. These datasets were introduced in October 2024 and are refreshed on a bi-weekly schedule:\n\u2022\t[LAPD NIBRS Offenses Dataset | Los Angeles Open Data Portal]\n\u2022\t[LAPD NIBRS Victims Dataset | Los Angeles Open Data Portal]\nThe adoption of NIBRS ensures LAPD crime and arrest data meet national standards, enhancing transparency, accuracy, and accessibility for the public.\n******\n\nOn March 7th, 2024, the Los Angeles Police Department (LAPD)  adopted a new Records Management System for reporting crimes and arrests. This new system is implemented to comply with the FBI's mandate to collect NIBRS-only data (NIBRS \u2014 FBI - https://www.fbi.gov/how-we-can-help-you/more-fbi-services-and-information/ucr/nibrs).\n\nThis dataset reflects incidents of crime in the City of Los Angeles dating back to 2020. This data is transcribed from original crime reports that are typed on paper and therefore there may be some inaccuracies within the data. Some location fields with missing data are noted as (0\u00b0, 0\u00b0). Address fields are only provided to the nearest hundred block in order to maintain privacy. This data is as accurate as the data in the database. Please note questions or concerns in the comments.",
+        "distribution": [
+          {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.lacity.org/api/views/2nrs-mtv8/columns.json",
+            "describedByType": "application/json",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/query.json?accessType=DOWNLOAD",
+            "mediaType": "application/json"
+          },
+          {
+            "@type": "dcat:Distribution",
+            "describedBy": "https://data.lacity.org/api/views/2nrs-mtv8/columns.xml",
+            "describedByType": "application/xml",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/query.xml?accessType=DOWNLOAD",
+            "mediaType": "application/xml"
+          },
+          {
+            "@type": "dcat:Distribution",
+            "downloadURL": "https://data.lacity.org/api/v3/views/2nrs-mtv8/export.csv?accessType=DOWNLOAD",
+            "mediaType": "text/csv"
+          }
+        ],
+        "identifier": "https://data.lacity.org/api/views/2nrs-mtv8",
+        "issued": "2020-02-10",
+        "keyword": [
+          "crime",
+          "crime data",
+          "crimes",
+          "lapd",
+          "police",
+          "safe city"
+        ],
+        "landingPage": "https://data.lacity.org/d/2nrs-mtv8",
+        "license": "http://creativecommons.org/publicdomain/zero/1.0/legalcode",
+        "modified": "2026-03-04",
+        "publisher": {
+          "@type": "org:Organization",
+          "name": "data.lacity.org"
+        },
+        "theme": [
+          "Public Safety"
+        ],
+        "title": "Crime Data from 2020 to 2024"
+      },
+      "description": "******Notice: Transition to NIBRS-Compliant Crime Data Reporting\nThe Los Angeles Police Department (LAPD) has completed its transition from the legacy Records Management System, which reported crime and arrest data under Uniform Crime Reporting (UCR) standards, to a modernized system fully aligned with the National Incident-Based Reporting System (NIBRS).\nAs part of this transition, the legacy system is no longer active, and no new information will be entered. Consequently, the Crime Data from 2020 to Present dataset will no longer be updated. It will remain available on the portal for historical reference only.\nTo provide the public with current and comprehensive information, LAPD now publishes datasets sourced directly from the new Records Management System in accordance with NIBRS standards. These datasets were introduced in October 2024 and are refreshed on a bi-weekly schedule:\n\u2022\t[LAPD NIBRS Offenses Dataset | Los Angeles Open Data Portal]\n\u2022\t[LAPD NIBRS Victims Dataset | Los Angeles Open Data Portal]\nThe adoption of NIBRS ensures LAPD crime and arrest data meet national standards, enhancing transparency, accuracy, and accessibility for the public.\n******\n\nOn March 7th, 2024, the Los Angeles Police Department (LAPD)  adopted a new Records Management System for reporting crimes and arrests. This new system is implemented to comply with the FBI's mandate to collect NIBRS-only data (NIBRS \u2014 FBI - https://www.fbi.gov/how-we-can-help-you/more-fbi-services-and-information/ucr/nibrs).\n\nThis dataset reflects incidents of crime in the City of Los Angeles dating back to 2020. This data is transcribed from original crime reports that are typed on paper and therefore there may be some inaccuracies within the data. Some location fields with missing data are noted as (0\u00b0, 0\u00b0). Address fields are only provided to the nearest hundred block in order to maintain privacy. This data is as accurate as the data in the database. Please note questions or concerns in the comments.",
+      "distribution_titles": [],
+      "harvest_record": "https://catalog.data.gov/harvest_record/3746c46c-0f5f-4f74-9a04-363ccc849aa6",
+      "harvest_record_raw": "https://catalog.data.gov/harvest_record/3746c46c-0f5f-4f74-9a04-363ccc849aa6/raw",
+      "has_download": true,
+      "has_spatial": false,
+      "identifier": "https://data.lacity.org/api/views/2nrs-mtv8",
+      "keyword": [
+        "crime",
+        "crime data",
+        "crimes",
+        "lapd",
+        "police",
+        "safe city"
+      ],
+      "last_harvested_date": "2026-08-11T23:12:29.196783",
+      "organization": {
+        "aliases": [
+          "la",
+          "california"
+        ],
+        "description": null,
+        "id": "aa795a1b-5fbb-46d1-b9f2-8b86e1e48bef",
+        "logo": "",
+        "name": "City of Los Angeles",
+        "organization_type": "City Government",
+        "slug": "los-angeles-ca"
+      },
+      "popularity": 1833,
+      "publisher": "data.lacity.org",
+      "slug": "crime-data-from-2020-to-present",
+      "spatial_centroid": null,
+      "spatial_shape": null,
+      "theme": [
+        "Public Safety"
+      ],
+      "title": "Crime Data from 2020 to 2024"
+    }
+  ],
+  "search_after": null,
+  "total": 1
+}

--- a/data-gov-ckan/src/client.rs
+++ b/data-gov-ckan/src/client.rs
@@ -73,9 +73,84 @@ impl std::fmt::Debug for ApiKey {
 }
 
 impl Configuration {
+    /// Assemble a [`Configuration`] around an already-built client.
+    ///
+    /// Every constructor funnels through here so the defaults are written
+    /// once, and so the fallible constructors never reach
+    /// [`Default::default`] -- which builds a client of its own, and panics
+    /// if it cannot.
+    fn with_client(client: reqwest::Client) -> Configuration {
+        Configuration {
+            // This crate serves any compliant CKAN deployment, not one
+            // portal, so there is no principled reason to default to one
+            // government's live service over another's -- Canada's,
+            // Ireland's, and Australia's all appear in this crate's own
+            // fixtures with equal standing. Defaulting to any of them sends
+            // live traffic to a third party that never consented to it
+            // (previously open.canada.ca, silently, from every unconfigured
+            // client). `.invalid` is reserved by RFC 2606 and never
+            // resolves, so an unconfigured client fails fast and loud with
+            // RequestError -- not a confusing 404 that reads like the
+            // request itself, rather than the configuration, is broken.
+            // Point this at your own CKAN-compatible portal.
+            base_path: "https://ckan.example.invalid/api/3".to_owned(),
+            user_agent: Some(concat!("data-gov-rs/", env!("CARGO_PKG_VERSION")).to_owned()),
+            client,
+            basic_auth: None,
+            oauth_access_token: None,
+            bearer_access_token: None,
+            api_key: None,
+        }
+    }
+
     /// Create a new configuration with default values
+    ///
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all -- a TLS backend,
+    /// proxy, or DNS resolver that will not start. Nothing can be returned in
+    /// that case: `reqwest::Client::new` fails the same way. Use
+    /// [`Configuration::try_new`] to receive it as an error instead.
     pub fn new() -> Configuration {
         Configuration::default()
+    }
+
+    /// Create a configuration with default values, reporting a client
+    /// construction failure instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// [`CkanError::RequestError`] when reqwest cannot construct an HTTP
+    /// client: TLS backend, proxy, or DNS resolver setup. There is no
+    /// degraded client to fall back to, so a consumer that must not panic
+    /// should report this and stop.
+    ///
+    /// ```rust
+    /// # use data_gov_ckan::Configuration;
+    /// let config = Configuration::try_new()?;
+    /// assert!(config.base_path.ends_with("/api/3"));
+    /// # Ok::<(), data_gov_ckan::CkanError>(())
+    /// ```
+    pub fn try_new() -> Result<Configuration, CkanError> {
+        Configuration::try_with_timeouts(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT)
+    }
+
+    /// Build a [`Configuration`] with the given timeouts, reporting a client
+    /// construction failure instead of panicking.
+    ///
+    /// The fallible counterpart of [`Configuration::with_timeouts`].
+    ///
+    /// # Errors
+    ///
+    /// [`CkanError::RequestError`] when reqwest cannot construct an HTTP
+    /// client. Timeout values themselves are never rejected.
+    pub fn try_with_timeouts(
+        connect_timeout: Duration,
+        timeout: Duration,
+    ) -> Result<Configuration, CkanError> {
+        Ok(Configuration::with_client(try_finish_client(
+            client_builder(connect_timeout, timeout),
+        )?))
     }
 
     /// Build a [`Configuration`] whose [`Self::client`] has the given
@@ -95,52 +170,87 @@ impl Configuration {
     ///     ..Configuration::with_timeouts(Duration::from_secs(5), Duration::from_secs(15))
     /// };
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all. See
+    /// [`Configuration::new`]; [`Configuration::try_with_timeouts`] returns
+    /// that failure as an error.
     pub fn with_timeouts(connect_timeout: Duration, timeout: Duration) -> Configuration {
-        Configuration {
-            client: build_client(connect_timeout, timeout),
-            ..Configuration::default()
-        }
+        Configuration::with_client(build_client(connect_timeout, timeout))
+    }
+}
+
+/// The builder every client in this module is finished from.
+fn client_builder(connect_timeout: Duration, timeout: Duration) -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .connect_timeout(connect_timeout)
+        .timeout(timeout)
+}
+
+/// Finish a [`reqwest::ClientBuilder`], reporting a build failure as an error.
+///
+/// # Errors
+///
+/// [`CkanError::RequestError`], carrying reqwest's own message, when no client
+/// can be constructed. In reqwest 0.13 `ClientBuilder::build` fails only for
+/// TLS backend, proxy, or DNS resolver setup -- never for a timeout value.
+fn try_finish_client(builder: reqwest::ClientBuilder) -> Result<reqwest::Client, CkanError> {
+    builder
+        .build()
+        .map_err(|e| CkanError::RequestError(Box::new(e)))
+}
+
+/// Finish a [`reqwest::ClientBuilder`] for a constructor that has no `Result`
+/// to propagate through.
+///
+/// There is deliberately no fallback client. #48 accepted an untimed client as
+/// a fallback on the premise that it beat no client at all, but the fallback it
+/// used cannot deliver one: `reqwest::Client::new` and
+/// `<reqwest::Client as Default>::default` call the same `ClientBuilder::build`
+/// and `expect` its result, so a TLS backend, proxy, or DNS resolver that will
+/// not start fails there too -- and panics with the bare text `Client::new()`,
+/// which names neither the crate nor the cause. Worse, for a builder failure
+/// that reqwest's own default does not share, the fallback quietly hands back a
+/// client with no timeouts at all, which is the failure #48 existed to close.
+///
+/// # Panics
+///
+/// When reqwest cannot construct a client at all. [`Configuration::try_new`]
+/// and [`Configuration::try_with_timeouts`] return that failure as a
+/// [`CkanError`] instead.
+fn finish_client(builder: reqwest::ClientBuilder) -> reqwest::Client {
+    match builder.build() {
+        Ok(client) => client,
+        Err(e) => panic!(
+            "data-gov-ckan: no HTTP client could be constructed. reqwest's \
+             client builder failed, which happens for TLS backend, proxy, or \
+             DNS resolver setup - never for a timeout value. \
+             reqwest::Client::new() fails the same way, so there is no \
+             fallback client to return. Use Configuration::try_new or \
+             Configuration::try_with_timeouts to handle this as an error. \
+             Cause: {e}"
+        ),
     }
 }
 
 /// Build a [`reqwest::Client`] with an explicit connect and request timeout.
 ///
-/// `ClientBuilder::build()` only fails for structurally invalid client
-/// configuration (a bad TLS backend or proxy setup); a builder that sets only
-/// timeouts cannot fail in practice. Fall back to an untimed client rather
-/// than panicking, per #48's acceptance criteria -- a client with no timeout
-/// is still strictly better than no client at all.
+/// # Panics
+///
+/// See [`finish_client`].
 fn build_client(connect_timeout: Duration, timeout: Duration) -> reqwest::Client {
-    reqwest::Client::builder()
-        .connect_timeout(connect_timeout)
-        .timeout(timeout)
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
+    finish_client(client_builder(connect_timeout, timeout))
 }
 
 impl Default for Configuration {
+    /// # Panics
+    ///
+    /// If reqwest cannot construct an HTTP client at all. See
+    /// [`Configuration::new`], whose [`Configuration::try_new`] counterpart
+    /// returns that failure as an error.
     fn default() -> Self {
-        Configuration {
-            // This crate serves any compliant CKAN deployment, not one
-            // portal, so there is no principled reason to default to one
-            // government's live service over another's -- Canada's,
-            // Ireland's, and Australia's all appear in this crate's own
-            // fixtures with equal standing. Defaulting to any of them sends
-            // live traffic to a third party that never consented to it
-            // (previously open.canada.ca, silently, from every unconfigured
-            // client). `.invalid` is reserved by RFC 2606 and never
-            // resolves, so an unconfigured client fails fast and loud with
-            // RequestError -- not a confusing 404 that reads like the
-            // request itself, rather than the configuration, is broken.
-            // Point this at your own CKAN-compatible portal.
-            base_path: "https://ckan.example.invalid/api/3".to_owned(),
-            user_agent: Some(concat!("data-gov-rs/", env!("CARGO_PKG_VERSION")).to_owned()),
-            client: build_client(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT),
-            basic_auth: None,
-            oauth_access_token: None,
-            bearer_access_token: None,
-            api_key: None,
-        }
+        Configuration::with_client(build_client(DEFAULT_CONNECT_TIMEOUT, DEFAULT_TIMEOUT))
     }
 }
 
@@ -1116,5 +1226,74 @@ mod tests {
             "expected the 100ms timeout to fire well before the mock's 10s \
              delay; took {elapsed:?}"
         );
+    }
+
+    /// A builder that cannot be built, so the no-client-at-all paths can be
+    /// exercised on a host whose TLS backend works.
+    ///
+    /// `\n` is not a legal header value, so `ClientBuilder::user_agent`
+    /// stores the error and `build()` returns it. That is the same `Err` a
+    /// TLS backend failure produces, and it is the only one reachable from a
+    /// test: this crate's builder sets nothing but timeouts, and a timeout
+    /// value cannot fail.
+    fn unbuildable_client() -> reqwest::ClientBuilder {
+        reqwest::Client::builder().user_agent("\n")
+    }
+
+    /// When reqwest can build no client, neither can this crate: `Client::new`
+    /// and `Client::default` call the same failing builder. The panic is
+    /// therefore unavoidable, and what the caller reads must name the crate,
+    /// the causes to look at, and the fallible constructor that returns the
+    /// failure instead -- not reqwest's bare `Client::new()`, and never a
+    /// silently substituted client with no timeouts.
+    #[test]
+    fn client_construction_failure_panics_with_a_message_naming_the_cause() {
+        let payload = std::panic::catch_unwind(|| finish_client(unbuildable_client()))
+            .expect_err("a builder that cannot build must not yield a client");
+        let message = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&str>().copied())
+            .unwrap_or("<non-string panic payload>");
+
+        for expected in ["data-gov-ckan", "TLS", "try_new"] {
+            assert!(
+                message.contains(expected),
+                "panic message must name {expected:?}, got {message:?}"
+            );
+        }
+    }
+
+    /// The fallible constructors exist so a consumer can report the failure
+    /// and exit cleanly rather than take a panic from a library.
+    #[test]
+    fn try_finish_client_reports_a_construction_failure_as_a_request_error() {
+        let error = try_finish_client(unbuildable_client())
+            .expect_err("a builder that cannot build must fail");
+
+        assert!(
+            matches!(error, CkanError::RequestError(_)),
+            "expected RequestError, got {error:?}"
+        );
+        let rendered = error.to_string();
+        assert!(
+            rendered.len() > "Request error: ".len(),
+            "the error must carry reqwest's own reason, got {rendered:?}"
+        );
+    }
+
+    /// On a host that can build a client at all, the fallible constructors
+    /// return the same configuration as the panicking ones.
+    #[test]
+    fn try_new_and_try_with_timeouts_return_the_documented_defaults() {
+        let config = Configuration::try_new().expect("a client builds on this host");
+        assert_eq!(config.base_path, Configuration::new().base_path);
+        assert_eq!(config.user_agent, Configuration::new().user_agent);
+        assert!(config.api_key.is_none(), "no credential is configured");
+
+        let timed =
+            Configuration::try_with_timeouts(Duration::from_secs(1), Duration::from_secs(2))
+                .expect("a client builds on this host");
+        assert_eq!(timed.base_path, config.base_path);
     }
 }

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -186,6 +186,12 @@ impl DataGovClient {
     ///
     /// Returns `Err(ResourceNotFound)` if no dataset matches.
     ///
+    /// Slugs only. An OpenSearch document id reaches the same endpoint and
+    /// resolves there, but yields `ResourceNotFound` here, because the
+    /// response carries nothing that ties the dataset back to the id that was
+    /// asked for -- see
+    /// [`CatalogClient::dataset_by_slug`](data_gov_catalog::CatalogClient::dataset_by_slug).
+    ///
     /// # Errors
     ///
     /// Returns [`DataGovError::ResourceNotFound`] if no dataset carries that

--- a/scripts/capture-fixtures.sh
+++ b/scripts/capture-fixtures.sh
@@ -81,6 +81,14 @@ HARVEST_WITH_TRANSFORM=$(curl -sS --fail --max-time 60 -H 'Accept: application/j
     "$BASE/search?per_page=1&org_slug=census" \
   | python3 -c 'import sys,json;print(json.load(sys.stdin)["results"][0]["harvest_record"].rstrip("/").split("/")[-1])')
 
+# The OpenSearch document id of $PINNED_SLUG. /api/dataset accepts it as well as
+# the slug, and the response it answers with carries no copy of it -- which is
+# why dataset_by_slug cannot verify a document-id lookup and returns None for
+# one. It is re-indexed on harvest, so it is discovered, never pinned.
+DOC_ID=$(curl -sS --fail --max-time 60 -H 'Accept: application/json' \
+    "$BASE/search?per_page=1&q=$PINNED_SLUG" \
+  | python3 -c "import sys,json;h=json.load(sys.stdin)['results'][0];sys.exit('top hit is %s, not the pinned slug' % h.get('slug')) if h.get('slug')!='$PINNED_SLUG' else print(h['_sort'][2])")
+
 # If a pinned dataset ever disappears, say so loudly rather than silently
 # capturing a fixture that no longer contains what the tests look for.
 for pinned in "$PINNED_SLUG" "$PINNED_SLUG_TRUNCATED"; do
@@ -92,7 +100,7 @@ for pinned in "$PINNED_SLUG" "$PINNED_SLUG_TRUNCATED"; do
   fi
 done
 
-echo "capturing from $BASE (harvest=$HARVEST harvest_with_transform=$HARVEST_WITH_TRANSFORM location=$LOCATION)"
+echo "capturing from $BASE (harvest=$HARVEST harvest_with_transform=$HARVEST_WITH_TRANSFORM location=$LOCATION doc_id=$DOC_ID)"
 
 # Success responses.
 get "/search?per_page=3"                              search.json
@@ -100,6 +108,7 @@ get "/search?per_page=3&org_slug=nasa"                search_filtered.json
 get "/search?per_page=3&q=$PINNED_SLUG"               search_by_slug.json
 get "/api/dataset/$PINNED_SLUG"                       dataset_by_slug.json
 get "/api/dataset/$PINNED_SLUG_TRUNCATED"             dataset_by_slug_truncated.json
+get "/api/dataset/$DOC_ID"                            dataset_by_document_id.json
 get "/api/organizations"                              organizations.json
 # size/min_count are echoed back in the response and asserted by client_tests.
 get "/api/keywords?size=10&min_count=5"               keywords.json


### PR DESCRIPTION
Fixes a behaviour defect confirmed by adversarial verification during the 0.5.0 release review, then independently reviewed from a fresh context.

Gate green in the authoring worktree; the reviewer re-ran it on a clean checkout.

Full detail is in the commit body: what changed, the tests added, and the mutation run to prove each test can fail.

Part of the 0.5.0 release-review sweep.