### PR TITLE
fix(cli,config): keep a failing exit code through a broken pipe, and stop clamping a zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they cloned; three commits had already landed on `data-gov-catalog/src` while
   `data-gov` was pinned to a published version. Each edge now declares both
   `version` and `path`, and the patch table is gone.
+- **`DataGovConfig::with_max_concurrent_downloads(0)` no longer becomes 1**
+  (#73, #107). The setter clamped a zero to one and said nothing, so a caller
+  who asked for 0 got a working client built from a number they never chose -
+  while the sibling `with_download_timeout(0)` passed its zero straight through
+  to a named `ConfigError`, and `ConfigResolver` rejected a zero from the flag,
+  environment, or config file. One value had three paths and only the
+  documented happy path was silent. The value now reaches
+  `DataGovClient::with_config`, which refuses it with a `ConfigError` naming
+  `max_concurrent_downloads`.
+
+  **What changes for you:** if you passed `0` and relied on the clamp, pass `1`
+  instead - `with_config` now returns `Err` for `0`. Any other value behaves
+  exactly as before.
 - All dependencies refreshed to their latest semver-compatible releases.
   `rustyline` 17 → 18 is deliberately **not** included; it is a major bump
   under the whole REPL and is tracked separately.
@@ -346,11 +359,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on a write error. That is one of the most ordinary ways a Unix CLI is used,
   and every command with enough output was affected, not just this one. The
   CLI now writes user-facing lines through `outln!` and `errln!`, which
-  recognise `BrokenPipe`: stdout stops the process quietly with exit 0,
-  because a reader that has seen enough is not an error; stderr drops the
-  line and lets the command finish, so a lost stderr cannot overwrite a
-  failing exit code with success. Any other write error stays as loud as it
-  was. The usual `SIGPIPE` fix needs `unsafe`, which this project forbids.
+  recognise `BrokenPipe`: the closed pipe is recorded, every later line to
+  that stream is dropped, and the command runs to its natural end and exits
+  with the code it would have returned anyway. A reader that has seen enough
+  is not an error, so a command that succeeded still exits 0 - but a command
+  that failed still exits non-zero, and destructors still run, neither of
+  which survives a `process::exit` taken at the first broken write. The cost
+  is that `data-gov list organizations | head -5` now finishes fetching
+  rather than stopping at the fifth line. Any other write error stays as loud
+  as it was. The usual `SIGPIPE` fix needs `unsafe`, which this project
+  forbids.
   `just check-print-macros` now fails the build if a bare `println!` returns
   to the CLI.
 - **`DataGovError::sanitized_message` no longer leaks the paths it promises to

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -1197,6 +1197,27 @@ mod tests {
         }
     }
 
+    /// The builder path and the struct-literal path must end in the same
+    /// place. A clamp inside `with_max_concurrent_downloads` would hand a
+    /// caller who asked for 0 a working client built from a number they
+    /// never chose, with no error anywhere saying so.
+    #[test]
+    fn a_zero_from_the_builder_reaches_the_named_error_rather_than_being_clamped() {
+        let config = crate::config::DataGovConfig::new().with_max_concurrent_downloads(0);
+
+        let err = DataGovClient::with_config(config)
+            .expect_err("a zero from the builder must be refused, not silently become 1");
+        match err {
+            DataGovError::ConfigError { message } => {
+                assert!(
+                    message.contains("max_concurrent_downloads"),
+                    "the error must name the field, got: {message}"
+                );
+            }
+            other => panic!("expected ConfigError, got {other:?}"),
+        }
+    }
+
     #[test]
     fn with_config_accepts_the_smallest_valid_values() {
         let config = crate::config::DataGovConfig {

--- a/data-gov/src/config.rs
+++ b/data-gov/src/config.rs
@@ -84,7 +84,12 @@ pub struct DataGovConfig {
     /// [`get_base_download_dir`](Self::get_base_download_dir) discarded it
     /// whenever the mode was `CommandLine`.
     pub base_download_dir: Option<PathBuf>,
-    /// Maximum concurrent downloads
+    /// Maximum concurrent downloads.
+    ///
+    /// Must be at least 1.
+    /// [`DataGovClient::with_config`](crate::DataGovClient::with_config)
+    /// refuses a zero, which would build a semaphore with no permits and
+    /// stall every download with no error (#73).
     pub max_concurrent_downloads: usize,
     /// How long a download may stall, in seconds.
     ///
@@ -243,9 +248,18 @@ impl DataGovConfig {
             .unwrap_or(DEFAULT_USER_AGENT)
     }
 
-    /// Set the maximum concurrent downloads.
+    /// Set how many downloads may run at once.
+    ///
+    /// The value is stored as given, `0` included.
+    /// [`DataGovClient::with_config`](crate::DataGovClient::with_config)
+    /// refuses `0`, naming the setting, because a zero-permit semaphore
+    /// never closes and would stall every download with no error (#73).
+    /// Failing there beats clamping here: a clamp builds a working client
+    /// from a number the caller never chose and says nothing about it. The
+    /// sibling [`with_download_timeout`](Self::with_download_timeout)
+    /// passes its own zero through to the same named error.
     pub fn with_max_concurrent_downloads(mut self, max: usize) -> Self {
-        self.max_concurrent_downloads = max.max(1);
+        self.max_concurrent_downloads = max;
         self
     }
 
@@ -344,6 +358,22 @@ mod tests {
 
     struct NullReporter;
     impl StatusReporter for NullReporter {}
+
+    /// The builder is a convenience, never the enforcement. A clamp here
+    /// would quietly substitute 1 for the 0 the caller asked for, hiding a
+    /// value that [`crate::DataGovClient::with_config`] rejects by name -
+    /// and the sibling setter `with_download_timeout` already passes its
+    /// own zero straight through to that same named error.
+    #[test]
+    fn with_max_concurrent_downloads_keeps_the_zero_the_caller_asked_for() {
+        let config = DataGovConfig::new().with_max_concurrent_downloads(0);
+
+        assert_eq!(
+            config.max_concurrent_downloads, 0,
+            "the builder must not override the caller: 0 has to survive to \
+             with_config, which refuses it by name"
+        );
+    }
 
     /// #77: `without_status_reporter` had zero callers, zero tests. It is
     /// the natural complement of `with_status_reporter`, which the CLI does

--- a/data-gov/tests/cli_broken_pipe_tests.rs
+++ b/data-gov/tests/cli_broken_pipe_tests.rs
@@ -15,9 +15,11 @@
 //!
 //! The project forbids `unsafe` (CLAUDE.md), which rules out the usual
 //! `signal(SIGPIPE, SIG_DFL)` fix, so the contract under test is the safe
-//! one: recognise the closed pipe at the print boundary and exit quietly.
+//! one: recognise the closed pipe at the print boundary, drop the line and
+//! every later one, and let the command finish and exit with its own code.
+//! A command that succeeded still exits 0; one that failed still does not.
 
-use std::io::Read;
+use std::io::{Read, Write};
 use std::process::{Command, Stdio};
 
 /// Path to the `data-gov` binary under test, built by cargo.
@@ -120,5 +122,41 @@ fn a_closed_stdout_pipe_does_not_silence_a_real_error() {
         run.status.code(),
         Some(0),
         "an unknown command must still exit non-zero when stdout is closed"
+    );
+}
+
+/// A closed stdout must not overwrite a failing exit code with success.
+///
+/// The script writes to stdout on its first line and fails on its second,
+/// which is the shape that mattered: any command that prints before it
+/// fails - the download path reporting "N of M download(s) failed" is the
+/// live example - reached stdout first, and an exit taken there discarded
+/// the failure the caller was waiting for. The exit code is the only
+/// signal left once the pipe is closed, so it has to be the command's own.
+#[test]
+fn a_failing_command_still_exits_non_zero_when_stdout_is_closed() {
+    let mut script = tempfile::NamedTempFile::new().expect("temp script file");
+    // `info` prints to stdout with no network; the closed pipe is hit here.
+    writeln!(script, "info").expect("write script");
+    // A known command with an unknown subject: fails locally, no network.
+    writeln!(script, "list bogus-subject").expect("write script");
+    script.flush().expect("flush script");
+    let path = script.path().display().to_string();
+
+    let run = run_with_closed_stdout(&["--color", "never", &path]);
+
+    assert_ne!(
+        run.status.code(),
+        Some(0),
+        "a command that failed must report that failure in its exit code even \
+         though nobody was reading stdout. Got exit {:?}, stderr: {}",
+        run.status.code(),
+        run.stderr
+    );
+    assert!(
+        run.stderr.contains("Error:"),
+        "the command must run to its natural end and report the failure on \
+         stderr, got stderr: {}",
+        run.stderr
     );
 }

--- a/data-gov/tools/cli/ui/output.rs
+++ b/data-gov/tools/cli/ui/output.rs
@@ -13,22 +13,42 @@
 //! [`errln!`] replace `println!` and `eprintln!` throughout the CLI.
 //! `just check-print-macros` fails the build if a bare `println!` returns.
 //!
-//! The two streams are treated differently on purpose:
+//! Neither stream ends the process, and for the same reason: once a pipe
+//! is closed the exit code is the only signal a caller has left, so it has
+//! to stay the command's own.
 //!
-//! - **stdout** carries the answer. Nobody is reading it any more, so the
-//!   process stops, quietly and successfully. A reader that has seen
-//!   enough is not an error, which is why `ls | head` does not report one.
-//! - **stderr** carries diagnostics. A lost stderr must *not* end the
-//!   process, because the exit code is the only signal a caller has left:
-//!   exiting 0 here would report success for a command that failed. The
-//!   line is dropped and the command finishes and reports as it would
-//!   have.
+//! - **stdout** carries the answer. The first `BrokenPipe` is recorded in
+//!   a process-global flag and every later stdout line is dropped without
+//!   a write attempt, so the command runs to its natural end and exits
+//!   with the code it would have returned anyway. A reader that has seen
+//!   enough is not an error, which is why `ls | head` does not report one,
+//!   so a command that succeeded still exits 0 and the closed-pipe tests
+//!   pin exactly that. Exiting here instead would report success for a
+//!   command that went on to fail (the download path returns "N of M
+//!   download(s) failed" long after its first line of output), and would
+//!   skip every destructor still on the stack on the way out.
+//! - **stderr** carries diagnostics. The line is dropped and the command
+//!   finishes and reports as it would have.
+//!
+//! The cost of not exiting is that a long command keeps working after its
+//! reader leaves: `data-gov list organizations | head -5` now fetches every
+//! page rather than stopping at the fifth line. That is the price of an
+//! honest exit code, and it is bounded by what the command was going to do
+//! anyway.
 //!
 //! Any other write error keeps the old loud behaviour, so a genuinely
 //! broken stdout is still not silent.
 
 use std::fmt::Arguments;
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// Set once stdout's reader has closed the pipe.
+///
+/// Process-global because the descriptor is: every `outln!` anywhere in
+/// the process writes to the same stdout, so one closed pipe silences all
+/// of them.
+static STDOUT_READER_GONE: AtomicBool = AtomicBool::new(false);
 
 /// What one write to a user-facing stream did, and what it means for the
 /// process.
@@ -59,20 +79,56 @@ pub(crate) fn write_line<W: Write>(stream: &mut W, args: Arguments<'_>) -> Write
     }
 }
 
-/// Write one line to stdout, exiting quietly if nobody is reading it.
+/// Write one line to `stream` unless `reader_gone` already records that
+/// nobody is listening, and set that flag if this write is the one that
+/// finds the closed pipe.
+///
+/// The flag is a parameter rather than a read of [`STDOUT_READER_GONE`] so
+/// the suppression can be proved against a local flag, without a test
+/// silencing stdout for every other test sharing the process.
+pub(crate) fn write_line_once<W: Write>(
+    stream: &mut W,
+    args: Arguments<'_>,
+    reader_gone: &AtomicBool,
+) -> WriteOutcome {
+    // Relaxed is enough: the flag guards nothing but itself, and the worst
+    // a stale read can cost is one more write that returns BrokenPipe
+    // again and sets the flag a second time.
+    if reader_gone.load(Ordering::Relaxed) {
+        return WriteOutcome::ReaderGone;
+    }
+
+    let outcome = write_line(stream, args);
+    if outcome == WriteOutcome::ReaderGone {
+        reader_gone.store(true, Ordering::Relaxed);
+    }
+    outcome
+}
+
+/// Write one line to stdout, dropping it - and every line after it - once
+/// the reader has closed the pipe.
+///
+/// The command is left to finish and exit with its own code; see the
+/// module docs for why this must not exit the process.
 ///
 /// # Panics
 ///
 /// Panics if the write fails for any reason other than a closed pipe,
 /// matching what `println!` did before.
 pub(crate) fn stdout_line(args: Arguments<'_>) {
+    // Checked before the lock so a command that keeps printing to a stdout
+    // nobody reads does not queue on it just to discard each line.
+    if STDOUT_READER_GONE.load(Ordering::Relaxed) {
+        return;
+    }
+
     let mut stdout = io::stdout().lock();
-    match write_line(&mut stdout, args) {
+    match write_line_once(&mut stdout, args, &STDOUT_READER_GONE) {
         WriteOutcome::Written => {}
-        // Nobody is reading the answer, so there is no reason to keep
-        // producing it. Exit 0: the command did its job and the reader
-        // stopped listening, which is not a failure.
-        WriteOutcome::ReaderGone => std::process::exit(0),
+        // Deliberately not an exit: see the module docs. The line is
+        // dropped, the flag now suppresses the rest, and the command keeps
+        // its own exit code.
+        WriteOutcome::ReaderGone => {}
         WriteOutcome::Failed(kind) => panic!("failed printing to stdout: {kind}"),
     }
 }
@@ -95,8 +151,8 @@ pub(crate) fn stderr_line(args: Arguments<'_>) {
     }
 }
 
-/// Print a line to stdout, exiting quietly if the reader has closed the
-/// pipe. Drop-in replacement for `println!`.
+/// Print a line to stdout, dropping it if the reader has closed the pipe.
+/// Drop-in replacement for `println!`.
 macro_rules! outln {
     () => {
         $crate::ui::output::stdout_line(::std::format_args!(""))
@@ -153,6 +209,62 @@ mod tests {
         let outcome = write_line(&mut stream, format_args!("anything"));
 
         assert_eq!(outcome, WriteOutcome::ReaderGone);
+    }
+
+    #[test]
+    fn a_healthy_stream_writes_the_line_and_leaves_the_reader_flag_clear() {
+        let reader_gone = AtomicBool::new(false);
+        let mut sink = Vec::new();
+
+        let outcome = write_line_once(&mut sink, format_args!("still listening"), &reader_gone);
+
+        assert_eq!(outcome, WriteOutcome::Written);
+        assert!(!reader_gone.load(Ordering::Relaxed));
+        assert_eq!(String::from_utf8(sink).expect("utf-8"), "still listening\n");
+    }
+
+    /// The first closed pipe has to silence the rest of the run. Without
+    /// that, every later line repeats a write that can only fail, and the
+    /// flag standing in for the old exit would be doing nothing.
+    #[test]
+    fn a_closed_pipe_is_recorded_and_every_later_line_is_dropped_unwritten() {
+        let reader_gone = AtomicBool::new(false);
+        let mut closed = FailingWriter(io::ErrorKind::BrokenPipe);
+
+        let first = write_line_once(&mut closed, format_args!("first"), &reader_gone);
+
+        assert_eq!(first, WriteOutcome::ReaderGone);
+        assert!(
+            reader_gone.load(Ordering::Relaxed),
+            "the closed pipe must be recorded, not just reported once"
+        );
+
+        // A writer that would happily accept the line: only the flag can
+        // stop this one, so an empty sink proves the suppression.
+        let mut sink = Vec::new();
+        let second = write_line_once(&mut sink, format_args!("second"), &reader_gone);
+
+        assert_eq!(second, WriteOutcome::ReaderGone);
+        assert!(
+            sink.is_empty(),
+            "once the reader is gone no later line may be written, got {sink:?}"
+        );
+    }
+
+    /// A full disk must stay loud. Recording it as a departed reader would
+    /// silence stdout for the rest of the run and hide the fault.
+    #[test]
+    fn a_real_write_failure_does_not_record_a_departed_reader() {
+        let reader_gone = AtomicBool::new(false);
+        let mut stream = FailingWriter(io::ErrorKind::StorageFull);
+
+        let outcome = write_line_once(&mut stream, format_args!("anything"), &reader_gone);
+
+        assert_eq!(outcome, WriteOutcome::Failed(io::ErrorKind::StorageFull));
+        assert!(
+            !reader_gone.load(Ordering::Relaxed),
+            "a fault is not a reader that left, and must not silence stdout"
+        );
     }
 
     /// The quiet path must be specific to a closed pipe. Treating every


### PR DESCRIPTION
Fixes a behaviour defect confirmed by adversarial verification during the 0.5.0 release review, then independently reviewed from a fresh context.

Gate green in the authoring worktree; the reviewer re-ran it on a clean checkout.

Full detail is in the commit body: what changed, the tests added, and the mutation run to prove each test can fail.

Part of the 0.5.0 release-review sweep.