### PR TITLE
fix(release): tell an unreachable crates.io index apart from an unpublished crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
       run: just check-print-macros
       if: matrix.rust == 'stable'
 
+    # The release helpers decide whether an irreversible `cargo publish` runs.
+    # Testing them here, against a stub index, is the only place the 500 and
+    # the refused-connection paths get exercised before a tag depends on them.
+    - name: Check the crates.io release helpers
+      run: just check-release-helpers
+      if: matrix.rust == 'stable'
+
     - name: Check for unused dependencies
       run: just check-deps
       if: matrix.rust == 'stable'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,15 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
-    # Two small helpers, not tracked scripts.
+    # The three publish helpers live in scripts/release/ and are called
+    # directly from the steps below.
     #
-    # `index-has` asks the crates.io sparse index - the same index cargo
-    # resolves against - whether a name/version pair is visible yet.
+    # `index-has.sh` asks the crates.io sparse index - the same index cargo
+    # resolves against - whether a name/version pair is visible yet. It
+    # answers three ways, not two: published, absent, or unknown. A blip that
+    # it reported as absent would be read as "publish this".
     #
-    # `publish-crate` uses it to make publishing idempotent. A crates.io
+    # `publish-crate.sh` uses it to make publishing idempotent. A crates.io
     # publish cannot be undone, only yanked, and yanking does not free the
     # version number. So if this job fails partway through, the natural
     # recovery - GitHub's "Re-run failed jobs" - would re-attempt the
@@ -152,67 +155,21 @@ jobs:
     # already exists", blocking every crate after the failure point and
     # leaving the release half-done with no in-workflow way to finish it.
     # Skipping what is already live makes a re-run resume instead of jam.
+    # An index it cannot get an answer from stops the job for an operator
+    # rather than publishing on a guess.
     #
-    # `wait-for-crate` polls rather than sleeping a fixed amount: crates.io
+    # `wait-for-crate.sh` polls rather than sleeping a fixed amount: crates.io
     # serializes index updates and the real delay varies with load, so a
     # fixed sleep is either too short under load or wastes minutes when the
     # index is already current. It fails loudly after a bounded ceiling
     # instead of hanging.
-    - name: Write the crates.io index helpers
-      run: |
-        cat > /tmp/index-has.sh <<'SCRIPT'
-        #!/usr/bin/env bash
-        # Exit 0 if <name> <version> is visible in the crates.io sparse index.
-        set -uo pipefail
-        name="$1"
-        version="$2"
-        len=${#name}
-        if [ "$len" -ge 4 ]; then
-          path="${name:0:2}/${name:2:2}/${name}"
-        elif [ "$len" -eq 3 ]; then
-          path="3/${name:0:1}/${name}"
-        elif [ "$len" -eq 2 ]; then
-          path="2/${name}"
-        else
-          path="1/${name}"
-        fi
-        curl -fsS "https://index.crates.io/${path}" 2>/dev/null \
-          | grep -q "\"vers\":\"${version}\""
-        SCRIPT
-
-        cat > /tmp/publish-crate.sh <<'SCRIPT'
-        #!/usr/bin/env bash
-        set -euo pipefail
-        name="$1"
-        version="$2"
-        if /tmp/index-has.sh "$name" "$version"; then
-          echo "${name} ${version} is already on crates.io; skipping."
-          exit 0
-        fi
-        echo "Publishing ${name} ${version}..."
-        cargo publish -p "$name" --locked
-        SCRIPT
-
-        cat > /tmp/wait-for-crate.sh <<'SCRIPT'
-        #!/usr/bin/env bash
-        set -euo pipefail
-        name="$1"
-        version="$2"
-        max_attempts=40
-        delay=15
-        echo "Waiting for ${name} ${version} to reach the crates.io index..."
-        for attempt in $(seq 1 "$max_attempts"); do
-          if /tmp/index-has.sh "$name" "$version"; then
-            echo "${name} ${version} is visible in the crates.io index."
-            exit 0
-          fi
-          echo "Attempt ${attempt}/${max_attempts}: not yet visible, waiting ${delay}s..."
-          sleep "$delay"
-        done
-        echo "::error::${name} ${version} did not appear in the crates.io index within $((max_attempts * delay))s. If crates.io is healthy, the publish may have failed silently - check the publish step above before re-running." >&2
-        exit 1
-        SCRIPT
-        chmod +x /tmp/index-has.sh /tmp/publish-crate.sh /tmp/wait-for-crate.sh
+    #
+    # They are tracked scripts rather than an inline heredoc so that
+    # `just check-release-helpers` can exercise them against a stub index on
+    # every CI run, including the 500, the rate-limit and the refused
+    # connection - none of which can be provoked on demand from the live
+    # service, and all of which run here on the one path that cannot be
+    # undone.
 
     # cargo reads CARGO_REGISTRY_TOKEN from the environment, so the token
     # never appears in a command line. An unset secret expands to an empty
@@ -232,19 +189,19 @@ jobs:
     # for it to be resolvable; data-gov-mcp-server depends on data-gov and
     # goes last, after its own wait.
     - name: Publish data-gov-catalog
-      run: /tmp/publish-crate.sh data-gov-catalog "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/publish-crate.sh data-gov-catalog "${{ needs.gate.outputs.version }}"
 
     - name: Publish data-gov-ckan
-      run: /tmp/publish-crate.sh data-gov-ckan "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/publish-crate.sh data-gov-ckan "${{ needs.gate.outputs.version }}"
 
     - name: Wait for data-gov-catalog to reach the crates.io index
-      run: /tmp/wait-for-crate.sh data-gov-catalog "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/wait-for-crate.sh data-gov-catalog "${{ needs.gate.outputs.version }}"
 
     - name: Publish data-gov
-      run: /tmp/publish-crate.sh data-gov "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/publish-crate.sh data-gov "${{ needs.gate.outputs.version }}"
 
     - name: Wait for data-gov to reach the crates.io index
-      run: /tmp/wait-for-crate.sh data-gov "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/wait-for-crate.sh data-gov "${{ needs.gate.outputs.version }}"
 
     - name: Publish data-gov-mcp-server
-      run: /tmp/publish-crate.sh data-gov-mcp-server "${{ needs.gate.outputs.version }}"
+      run: ./scripts/release/publish-crate.sh data-gov-mcp-server "${{ needs.gate.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `data_gov::catalog` re-export. The lockfile drops from 308 to 279 crates.
 
 ### Infrastructure
+- **A crates.io index it cannot reach no longer reads as "not published"**.
+  The release workflow probed the sparse index with
+  `curl -fsS ... | grep -q`, which exits non-zero identically for a genuine
+  404, a 500, a DNS failure and a reset connection. `publish-crate.sh` read
+  that single non-zero as "not on crates.io; publish it", so one transient
+  blip would run `cargo publish` against a version that was already live and
+  hard-fail on "crate version already exists" - the exact failure the skip
+  exists to prevent - blocking every crate behind it in the dependency chain.
+  That path is the documented recovery for a half-finished release, and a
+  publish cannot be undone, only yanked. The probe now reads curl's HTTP
+  status rather than inferring from its exit code, retries a bounded number
+  of times, and answers three ways: published, absent, or unknown. Unknown
+  stops the job with an error naming the situation instead of publishing on a
+  guess. The version is matched with `grep -F`, so the dots in `0.5.0` are
+  no longer wildcards that also match `0X5X0`.
+- **The release helpers are tracked scripts under `scripts/release/`, and
+  tested.** They were heredocs written to `/tmp` inside the workflow, which
+  cannot be unit-tested and so had never been run against a failing index.
+  `just check-release-helpers` now drives them against a stub index that
+  serves a 404, a 500, a rate-limit and a refused connection on demand - none
+  of which the live service can be asked for - and asserts that `cargo` is
+  never invoked when the index state is unknown. The workflow's behaviour,
+  publish order and dependency waits are unchanged.
 - **`clippy::missing_errors_doc` and `clippy::missing_panics_doc` are denied
   workspace-wide** (#59), and the 24 public `Result`-returning functions that
   had no `# Errors` section now have one naming the variants that call path can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -486,6 +486,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of which the live service can be asked for - and asserts that `cargo` is
   never invoked when the index state is unknown. The workflow's behaviour,
   publish order and dependency waits are unchanged.
+- **The index wait now has a ceiling it actually keeps**. `wait-for-crate.sh`
+  reported a bound of `attempts * delay`, but its `curl` had no timeout at
+  all, so a connection that hung stalled the release job with no limit. Each
+  probe is now capped by `--max-time`, the poll loop spends one probe per
+  poll rather than letting the probe retry inside the loop that is already
+  the retry, and the timeout message reports the seconds that actually
+  elapsed instead of a product that understated them.
 - **`clippy::missing_errors_doc` and `clippy::missing_panics_doc` are denied
   workspace-wide** (#59), and the 24 public `Result`-returning functions that
   had no `# Errors` section now have one naming the variants that call path can

--- a/justfile
+++ b/justfile
@@ -20,7 +20,7 @@ default:
     @just --list
 
 # The full gate. Run this before you push.
-check: fmt-check check-ascii check-home-paths check-print-macros check-deps lint build test check-rustls examples docs
+check: fmt-check check-ascii check-home-paths check-print-macros check-release-helpers check-deps lint build test check-rustls examples docs
 
 # Format every file in place.
 fmt:
@@ -57,6 +57,17 @@ check-home-paths:
 check-print-macros:
     python3 scripts/check-print-macros.py --self-test
     python3 scripts/check-print-macros.py
+
+# Fail if the crates.io release helpers get the index answer wrong.
+#
+# They run on the one path a mistake cannot be taken back from: a publish to
+# crates.io is permanent, and yanking does not free the version number. So
+# they must tell "the index says this version is absent" from "the index did
+# not answer", and only the first of those means publish. A stub index serves
+# the 404, the 500, the rate-limit and the refused connection on demand, none
+# of which the live service can be asked for. No network needed.
+check-release-helpers:
+    ./scripts/release/test-release-helpers.sh
 
 # Fail if a crate declares a dependency nothing imports.
 #

--- a/scripts/release/index-has.sh
+++ b/scripts/release/index-has.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Ask the crates.io sparse index whether <name> <version> is published.
+#
+# The answer is three-valued, not two, and the third value is the point of
+# this script. A publish to crates.io cannot be undone, only yanked, and
+# yanking does not free the version number - so "I could not tell" must never
+# collapse into "not published", which is an instruction to publish.
+#
+#   exit 0  published   - the index answered and lists this version
+#   exit 1  absent      - the index answered and does not list this version,
+#                         or has never heard of the crate (404)
+#   exit 2  unknown     - the index could not be reached, or answered with
+#                         something other than 200 or 404, and kept doing so
+#                         across every retry. The caller must stop.
+#
+# The status comes from curl's -w '%{http_code}', not from curl's exit code
+# alone: a 500, a reset connection and a genuine 404 are one single non-zero
+# exit to curl, and telling them apart is the whole job here.
+#
+# Environment:
+#   CRATES_INDEX_BASE_URL     index root (default https://index.crates.io)
+#   CRATES_INDEX_ATTEMPTS     probes before declaring unknown (default 5)
+#   CRATES_INDEX_RETRY_DELAY  seconds between probes (default 3)
+#   CRATES_INDEX_TIMEOUT      seconds allowed per probe (default 20)
+
+set -uo pipefail
+
+readonly EXIT_PUBLISHED=0
+readonly EXIT_ABSENT=1
+readonly EXIT_UNKNOWN=2
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: index-has.sh <crate-name> <version>" >&2
+  exit "$EXIT_UNKNOWN"
+fi
+
+name="$1"
+version="$2"
+base="${CRATES_INDEX_BASE_URL:-https://index.crates.io}"
+attempts="${CRATES_INDEX_ATTEMPTS:-5}"
+delay="${CRATES_INDEX_RETRY_DELAY:-3}"
+timeout_seconds="${CRATES_INDEX_TIMEOUT:-20}"
+
+# The sparse index shards crate files by name length; see the cargo book,
+# "Registry index" - Index files.
+len=${#name}
+if [ "$len" -ge 4 ]; then
+  path="${name:0:2}/${name:2:2}/${name}"
+elif [ "$len" -eq 3 ]; then
+  path="3/${name:0:1}/${name}"
+elif [ "$len" -eq 2 ]; then
+  path="2/${name}"
+else
+  path="1/${name}"
+fi
+url="${base}/${path}"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+body="${work}/body"
+curl_error="${work}/curl-error"
+
+# Matched with grep -F so the version is a literal. Read as a regex, the dots
+# in 0.5.0 are wildcards and the released 0X5X0 of some other crate would
+# answer for it.
+needle="\"vers\":\"${version}\""
+
+reason="no probe was attempted"
+for attempt in $(seq 1 "$attempts"); do
+  curl_status=0
+  http_code="$(
+    curl --silent --show-error --max-time "$timeout_seconds" \
+      --output "$body" --write-out '%{http_code}' "$url" 2>"$curl_error"
+  )" || curl_status=$?
+
+  if [ "$curl_status" -ne 0 ]; then
+    reason="curl exited ${curl_status}: $(tr '\n' ' ' <"$curl_error")"
+  else
+    case "$http_code" in
+      200)
+        if grep -qF -- "$needle" "$body"; then
+          exit "$EXIT_PUBLISHED"
+        fi
+        exit "$EXIT_ABSENT"
+        ;;
+      404)
+        exit "$EXIT_ABSENT"
+        ;;
+      *)
+        reason="the index answered HTTP ${http_code}"
+        ;;
+    esac
+  fi
+
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "index probe ${attempt}/${attempts} for ${name} ${version} failed (${reason}); retrying in ${delay}s..." >&2
+    sleep "$delay"
+  fi
+done
+
+echo "::error::the crates.io index could not be reached for ${name} ${version}: ${reason} (${attempts} attempts against ${url}). Whether this version is already published is unknown, and a publish cannot be undone, so nothing is published from here. Re-run once the index answers." >&2
+exit "$EXIT_UNKNOWN"

--- a/scripts/release/publish-crate.sh
+++ b/scripts/release/publish-crate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Publish <name> <version> to crates.io, unless it is already there.
+#
+# This makes a re-run of the publish job resume rather than jam. A crates.io
+# publish cannot be undone, only yanked, so a job that fails partway through
+# would otherwise re-attempt the publishes that already succeeded and
+# hard-fail on "crate version already exists", blocking every crate behind it.
+#
+# An index that cannot be answered for is not treated as "not published".
+# That mistake publishes on a network blip and produces the very failure the
+# skip exists to prevent, so this stops and asks for an operator instead.
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: publish-crate.sh <crate-name> <version>" >&2
+  exit 1
+fi
+
+name="$1"
+version="$2"
+
+probe=0
+"${here}/index-has.sh" "$name" "$version" || probe=$?
+
+case "$probe" in
+  0)
+    echo "${name} ${version} is already on crates.io; skipping."
+    exit 0
+    ;;
+  1)
+    ;;
+  *)
+    echo "::error::refusing to publish ${name} ${version}: the crates.io index did not answer, so whether this version is already published is unknown (probe exited ${probe}; the reason is above). Publishing blind risks a duplicate publish, which cannot be undone. Check crates.io, then re-run this job." >&2
+    exit 1
+    ;;
+esac
+
+echo "Publishing ${name} ${version}..."
+cargo publish -p "$name" --locked

--- a/scripts/release/stub-index-server.py
+++ b/scripts/release/stub-index-server.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""A stub crates.io sparse index, for testing the release helpers offline.
+
+The release helpers must never touch the live index from a test, so this
+serves canned answers instead: the crate file, a 404, a 500, an arbitrary
+status, or a run of failures followed by the real answer. It binds an
+ephemeral port on the loopback interface and prints ``PORT <n>`` on stdout
+before it serves, so the caller does not have to guess a free port.
+
+Modes:
+    ok            every request returns 200 and --body
+    missing       every request returns 404, as the index does for a crate
+                  it has never seen
+    server-error  every request returns 500
+    status        every request returns --status
+    flaky         the first --fail-first requests return 500, then 200
+    late          the first --fail-first requests return 404, then 200
+
+Usage:
+    stub-index-server.py --mode ok --body FILE
+    stub-index-server.py --mode status --status 429
+    stub-index-server.py --mode flaky --body FILE --fail-first 2
+"""
+
+import argparse
+import http.server
+import sys
+import threading
+
+
+def build_handler(args: argparse.Namespace, body: bytes) -> type:
+    """Return a request handler that answers according to `args.mode`."""
+    state = {"seen": 0}
+    lock = threading.Lock()
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:  # noqa: N802 - name fixed by the base class
+            with lock:
+                state["seen"] += 1
+                seen = state["seen"]
+
+            early = seen <= args.fail_first
+            if args.mode == "missing" or (args.mode == "late" and early):
+                self.send_error(404, "Not Found")
+                return
+            if args.mode == "server-error" or (args.mode == "flaky" and early):
+                self.send_error(500, "Internal Server Error")
+                return
+            if args.mode == "status":
+                self.send_error(args.status, "Stub Status")
+                return
+
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *fmt_args: object) -> None:
+            """Stay quiet; the test prints its own progress."""
+
+    return Handler
+
+
+def main() -> int:
+    """Parse the arguments and serve until killed."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        required=True,
+        choices=("ok", "missing", "server-error", "status", "flaky", "late"),
+    )
+    parser.add_argument("--body", help="file whose contents a 200 returns")
+    parser.add_argument(
+        "--status",
+        type=int,
+        default=500,
+        help="status code returned in --mode status",
+    )
+    parser.add_argument(
+        "--fail-first",
+        type=int,
+        default=0,
+        help="number of leading failures in --mode flaky and --mode late",
+    )
+    args = parser.parse_args()
+
+    body = b""
+    if args.body:
+        with open(args.body, "rb") as handle:
+            body = handle.read()
+
+    server = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", 0), build_handler(args, body)
+    )
+    print(f"PORT {server.server_address[1]}", flush=True)
+    server.serve_forever()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release/stub-index-server.py
+++ b/scripts/release/stub-index-server.py
@@ -40,6 +40,9 @@ def build_handler(args: argparse.Namespace, body: bytes) -> type:
             with lock:
                 state["seen"] += 1
                 seen = state["seen"]
+                if args.count_file:
+                    with open(args.count_file, "w") as handle:
+                        handle.write(f"{seen}\n")
 
             early = seen <= args.fail_first
             if args.mode == "missing" or (args.mode == "late" and early):
@@ -84,6 +87,11 @@ def main() -> int:
         type=int,
         default=0,
         help="number of leading failures in --mode flaky and --mode late",
+    )
+    parser.add_argument(
+        "--count-file",
+        help="file rewritten with the running request count, so a caller can "
+        "assert how many probes a helper actually made",
     )
     args = parser.parse_args()
 

--- a/scripts/release/test-release-helpers.sh
+++ b/scripts/release/test-release-helpers.sh
@@ -48,7 +48,9 @@ trap cleanup EXIT
 start_stub() {
   stop_stub
   : > "$tmp/stub.out"
-  python3 "$here/stub-index-server.py" "$@" > "$tmp/stub.out" 2> "$tmp/stub.err" &
+  : > "$tmp/probe-count"
+  python3 "$here/stub-index-server.py" --count-file "$tmp/probe-count" "$@" \
+    > "$tmp/stub.out" 2> "$tmp/stub.err" &
   stub_pid=$!
   local port=""
   for _ in $(seq 1 100); do
@@ -102,6 +104,24 @@ and_output_has() {
   else
     printf 'FAIL %s: output does not mention %s\n' "$name" "$needle"
     sed 's/^/       | /' "$tmp/out"
+    failed=$((failed + 1))
+  fi
+}
+
+and_probes_numbered() {
+  local name="$1" expected="$2"
+  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
+    return 0
+  fi
+  local actual
+  actual="$(cat "$tmp/probe-count" 2>/dev/null)"
+  actual="${actual:-0}"
+  if [ "$actual" -eq "$expected" ]; then
+    printf 'ok   %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s: expected %s probes, the index saw %s\n' \
+      "$name" "$expected" "$actual"
     failed=$((failed + 1))
   fi
 }
@@ -243,6 +263,15 @@ want wait_returns_once_the_version_appears \
 start_stub --mode missing
 want wait_fails_when_the_version_never_appears \
   1 wait_for_crate "$stub_base" data-gov-ckan 0.5.0
+
+# The poll loop is already the retry, so letting the probe retry inside it
+# would multiply the wait ceiling by the probe's attempt count. The bound is
+# stated in the error message this script prints, so it has to be real.
+start_stub --mode server-error
+CRATES_INDEX_ATTEMPTS="" \
+  want wait_does_not_multiply_its_ceiling_by_the_probe_retries \
+  1 wait_for_crate "$stub_base" data-gov-ckan 0.5.0
+and_probes_numbered wait_spends_one_probe_per_poll 3
 
 want wait_fails_when_the_index_stays_unreachable \
   1 wait_for_crate "$(unreachable_base)" data-gov-ckan 0.5.0

--- a/scripts/release/test-release-helpers.sh
+++ b/scripts/release/test-release-helpers.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Specification tests for the crates.io release helpers.
+#
+# These run offline against a stub index (scripts/release/stub-index-server.py),
+# because the behaviour under test is what the helpers do when the real index
+# answers badly - 404, 500, a rate-limit, a refused connection - and none of
+# that can be provoked on demand from the live service.
+#
+# The helpers sit on the irreversible path: a crates.io publish cannot be
+# undone, only yanked, and yanking does not free the version number. So the
+# case that matters most here is the guard, not the happy path - an index
+# that cannot be reached must stop the publish, never wave it through.
+#
+# Usage: test-release-helpers.sh [name-substring]
+
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+tmp="$(mktemp -d)"
+filter="${1:-}"
+
+# Exit codes the helpers use to tell the three outcomes apart.
+readonly PUBLISHED=0
+readonly NOT_PUBLISHED=1
+readonly UNKNOWN=2
+
+stub_pid=""
+stub_base=""
+passed=0
+failed=0
+
+stop_stub() {
+  if [ -n "$stub_pid" ]; then
+    kill "$stub_pid" 2>/dev/null
+    wait "$stub_pid" 2>/dev/null
+    stub_pid=""
+  fi
+}
+
+cleanup() {
+  stop_stub
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+
+# Start the stub index and point $stub_base at it. The stub binds port 0 and
+# reports the port it got, so parallel runs cannot collide on a fixed one.
+start_stub() {
+  stop_stub
+  : > "$tmp/stub.out"
+  python3 "$here/stub-index-server.py" "$@" > "$tmp/stub.out" 2> "$tmp/stub.err" &
+  stub_pid=$!
+  local port=""
+  for _ in $(seq 1 100); do
+    port="$(awk '/^PORT /{print $2; exit}' "$tmp/stub.out")"
+    [ -n "$port" ] && break
+    sleep 0.05
+  done
+  if [ -z "$port" ]; then
+    echo "stub index failed to start:" >&2
+    cat "$tmp/stub.err" >&2
+    exit 1
+  fi
+  stub_base="http://127.0.0.1:${port}"
+}
+
+# Nothing listens on port 1, so this stands in for a DNS failure, a dropped
+# connection, or crates.io being unreachable.
+unreachable_base() {
+  echo "http://127.0.0.1:1"
+}
+
+want() {
+  local name="$1" expected="$2"
+  shift 2
+  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
+    return 0
+  fi
+  : > "$tmp/cargo.log"
+  local actual=0
+  "$@" > "$tmp/out" 2>&1 || actual=$?
+  if [ "$actual" -eq "$expected" ]; then
+    printf 'ok   %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s: expected exit %s, got %s\n' "$name" "$expected" "$actual"
+    sed 's/^/       | /' "$tmp/out"
+    failed=$((failed + 1))
+  fi
+}
+
+# Assertions about the run `want` just made. Kept separate so one case can
+# check both the exit status and what the operator was told.
+and_output_has() {
+  local name="$1" needle="$2"
+  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
+    return 0
+  fi
+  if grep -qF -- "$needle" "$tmp/out"; then
+    printf 'ok   %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s: output does not mention %s\n' "$name" "$needle"
+    sed 's/^/       | /' "$tmp/out"
+    failed=$((failed + 1))
+  fi
+}
+
+and_cargo_ran() {
+  local name="$1"
+  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
+    return 0
+  fi
+  if [ -s "$tmp/cargo.log" ]; then
+    printf 'ok   %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL %s: cargo was never called\n' "$name"
+    failed=$((failed + 1))
+  fi
+}
+
+and_cargo_did_not_run() {
+  local name="$1"
+  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
+    return 0
+  fi
+  if [ -s "$tmp/cargo.log" ]; then
+    printf 'FAIL %s: cargo ran anyway: %s\n' "$name" "$(cat "$tmp/cargo.log")"
+    failed=$((failed + 1))
+  else
+    printf 'ok   %s\n' "$name"
+    passed=$((passed + 1))
+  fi
+}
+
+# A stand-in for cargo, so a test can tell whether a publish was attempted
+# without publishing anything. Real `cargo publish` is never called here.
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/cargo" <<'CARGO'
+#!/usr/bin/env bash
+echo "$@" >> "$CARGO_LOG"
+CARGO
+chmod +x "$tmp/bin/cargo"
+export CARGO_LOG="$tmp/cargo.log"
+export PATH="$tmp/bin:$PATH"
+
+# Two lines in the shape crates.io actually returns, with the dependency
+# arrays trimmed. The version under test, 0.5.0, is deliberately absent.
+cat > "$tmp/index-body.txt" <<'BODY'
+{"name":"data-gov-ckan","vers":"0.3.1","deps":[],"cksum":"0000000000000000000000000000000000000000000000000000000000000000","features":{},"yanked":false}
+{"name":"data-gov-ckan","vers":"0.4.0","deps":[],"cksum":"1111111111111111111111111111111111111111111111111111111111111111","features":{},"yanked":false}
+BODY
+
+# The same shape, carrying a version that matches 0.5.0 only if the dots are
+# read as regex wildcards.
+cat > "$tmp/index-regex-trap.txt" <<'BODY'
+{"name":"data-gov-ckan","vers":"0X5X0","deps":[],"cksum":"2222222222222222222222222222222222222222222222222222222222222222","features":{},"yanked":false}
+BODY
+
+# Keep the retries and the polling short. The defaults are tuned for a real
+# release; a test must not spend minutes proving a guard fires.
+export CRATES_INDEX_ATTEMPTS=3
+export CRATES_INDEX_RETRY_DELAY=0
+export CRATES_WAIT_ATTEMPTS=3
+export CRATES_WAIT_DELAY=0
+
+index_has() {
+  CRATES_INDEX_BASE_URL="$1" "$here/index-has.sh" "$2" "$3"
+}
+
+publish_crate() {
+  CRATES_INDEX_BASE_URL="$1" "$here/publish-crate.sh" "$2" "$3"
+}
+
+wait_for_crate() {
+  CRATES_INDEX_BASE_URL="$1" "$here/wait-for-crate.sh" "$2" "$3"
+}
+
+echo "== index-has.sh =="
+
+start_stub --mode ok --body "$tmp/index-body.txt"
+want reports_published_when_the_index_lists_the_version \
+  "$PUBLISHED" index_has "$stub_base" data-gov-ckan 0.4.0
+
+want reports_not_published_when_the_index_omits_the_version \
+  "$NOT_PUBLISHED" index_has "$stub_base" data-gov-ckan 0.5.0
+
+start_stub --mode missing
+want reports_not_published_when_the_index_returns_404 \
+  "$NOT_PUBLISHED" index_has "$stub_base" data-gov-ckan 0.5.0
+
+want reports_unknown_when_the_index_is_unreachable \
+  "$UNKNOWN" index_has "$(unreachable_base)" data-gov-ckan 0.5.0
+and_output_has reports_unknown_when_the_index_is_unreachable_and_says_so \
+  "could not be reached"
+
+start_stub --mode server-error
+want reports_unknown_when_the_index_returns_a_server_error \
+  "$UNKNOWN" index_has "$stub_base" data-gov-ckan 0.5.0
+
+start_stub --mode status --status 429
+want reports_unknown_when_the_index_rate_limits_the_probe \
+  "$UNKNOWN" index_has "$stub_base" data-gov-ckan 0.5.0
+
+start_stub --mode flaky --fail-first 2 --body "$tmp/index-body.txt"
+want retries_a_transient_server_error_before_answering \
+  "$PUBLISHED" index_has "$stub_base" data-gov-ckan 0.4.0
+
+start_stub --mode ok --body "$tmp/index-regex-trap.txt"
+want matches_the_version_literally_rather_than_as_a_regex \
+  "$NOT_PUBLISHED" index_has "$stub_base" data-gov-ckan 0.5.0
+
+echo "== publish-crate.sh =="
+
+start_stub --mode ok --body "$tmp/index-body.txt"
+want publish_skips_the_crate_when_the_index_lists_the_version \
+  0 publish_crate "$stub_base" data-gov-ckan 0.4.0
+and_cargo_did_not_run publish_skips_the_crate_without_calling_cargo
+
+start_stub --mode missing
+want publish_runs_cargo_when_the_index_does_not_list_the_version \
+  0 publish_crate "$stub_base" data-gov-ckan 0.5.0
+and_cargo_ran publish_runs_cargo_when_the_index_does_not_list_the_version_call
+
+want publish_refuses_when_the_index_state_is_unknown \
+  1 publish_crate "$(unreachable_base)" data-gov-ckan 0.5.0
+and_cargo_did_not_run publish_refuses_when_the_index_state_is_unknown_no_cargo
+and_output_has publish_names_the_unknown_index_state_in_its_error \
+  "could not be reached"
+
+start_stub --mode server-error
+want publish_refuses_when_the_index_returns_a_server_error \
+  1 publish_crate "$stub_base" data-gov-ckan 0.5.0
+and_cargo_did_not_run publish_refuses_on_a_server_error_without_calling_cargo
+
+echo "== wait-for-crate.sh =="
+
+start_stub --mode late --fail-first 1 --body "$tmp/index-body.txt"
+want wait_returns_once_the_version_appears \
+  0 wait_for_crate "$stub_base" data-gov-ckan 0.4.0
+
+start_stub --mode missing
+want wait_fails_when_the_version_never_appears \
+  1 wait_for_crate "$stub_base" data-gov-ckan 0.5.0
+
+want wait_fails_when_the_index_stays_unreachable \
+  1 wait_for_crate "$(unreachable_base)" data-gov-ckan 0.5.0
+and_output_has wait_names_the_unreachable_index_rather_than_a_missing_publish \
+  "could not be reached"
+
+stop_stub
+echo
+echo "passed: ${passed}, failed: ${failed}"
+[ "$failed" -eq 0 ]

--- a/scripts/release/wait-for-crate.sh
+++ b/scripts/release/wait-for-crate.sh
@@ -29,6 +29,11 @@ version="$2"
 max_attempts="${CRATES_WAIT_ATTEMPTS:-40}"
 delay="${CRATES_WAIT_DELAY:-15}"
 
+# This loop is already the retry, so the probe inside it does not need its own.
+# Left at the probe's default, every poll would cost several probes and the
+# ceiling below would be that many times longer than it says.
+export CRATES_INDEX_ATTEMPTS="${CRATES_INDEX_ATTEMPTS:-1}"
+
 echo "Waiting for ${name} ${version} to reach the crates.io index..."
 
 state="not yet visible"
@@ -54,5 +59,5 @@ for attempt in $(seq 1 "$max_attempts"); do
   sleep "$delay"
 done
 
-echo "::error::${name} ${version} did not appear in the crates.io index within $((max_attempts * delay))s: ${state}. ${advice}" >&2
+echo "::error::${name} ${version} did not appear in the crates.io index after ${max_attempts} polls over ${SECONDS}s: ${state}. ${advice}" >&2
 exit 1

--- a/scripts/release/wait-for-crate.sh
+++ b/scripts/release/wait-for-crate.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Block until <name> <version> is resolvable from the crates.io index.
+#
+# Polls rather than sleeping a fixed amount: crates.io serializes index
+# updates and the real delay varies with load, so a fixed sleep is either too
+# short under load or wastes minutes when the index is already current.
+#
+# An index that cannot be reached is a reason to keep waiting, not to stop -
+# waiting costs nothing and cannot be undone the way a publish can. The
+# ceiling still applies, and the error at the end names which of the two
+# happened, because "the version never appeared" and "the index never
+# answered" call for different responses from whoever reads it.
+#
+# Environment:
+#   CRATES_WAIT_ATTEMPTS  polls before giving up (default 40)
+#   CRATES_WAIT_DELAY     seconds between polls (default 15)
+
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: wait-for-crate.sh <crate-name> <version>" >&2
+  exit 1
+fi
+
+name="$1"
+version="$2"
+max_attempts="${CRATES_WAIT_ATTEMPTS:-40}"
+delay="${CRATES_WAIT_DELAY:-15}"
+
+echo "Waiting for ${name} ${version} to reach the crates.io index..."
+
+state="not yet visible"
+advice="If crates.io is healthy, the publish may have failed silently - check the publish step above before re-running."
+for attempt in $(seq 1 "$max_attempts"); do
+  probe=0
+  "${here}/index-has.sh" "$name" "$version" || probe=$?
+  case "$probe" in
+    0)
+      echo "${name} ${version} is visible in the crates.io index."
+      exit 0
+      ;;
+    1)
+      state="not yet visible"
+      advice="If crates.io is healthy, the publish may have failed silently - check the publish step above before re-running."
+      ;;
+    *)
+      state="the index could not be reached"
+      advice="The publish itself may well have succeeded; confirm on crates.io before re-running."
+      ;;
+  esac
+  echo "Attempt ${attempt}/${max_attempts}: ${state}, waiting ${delay}s..."
+  sleep "$delay"
+done
+
+echo "::error::${name} ${version} did not appear in the crates.io index within $((max_attempts * delay))s: ${state}. ${advice}" >&2
+exit 1


### PR DESCRIPTION
Fixes a behaviour defect confirmed by adversarial verification during the 0.5.0 release review, then independently reviewed from a fresh context.

Gate green in the authoring worktree; the reviewer re-ran it on a clean checkout.

Full detail is in the commit body: what changed, the tests added, and the mutation run to prove each test can fail.

Part of the 0.5.0 release-review sweep.