### PR TITLE
fix(mcp): stop the request timeout killing a download that is progressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -360,13 +360,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **The MCP request timeout no longer kills a download that is progressing**
+  (#131). Every method ran inside a 900-second wall-clock bound that is not
+  operator-tunable, `data_gov.downloadResources` among them, so a transfer that
+  was perfectly healthy was abandoned mid-flight at fifteen minutes. That is a
+  real size, not a corner: a 222 MB dataset over a 250 KB/s link is fifteen
+  minutes of honest work, and a 2 GB dataset on an ordinary home connection was
+  killed every time, after the user had already waited a quarter of an hour. No
+  constant can predict a transfer's runtime - it is the size of a file over the
+  width of a link - so the bound could only ever be wrong somewhere. Two things
+  already stop a download and both are unchanged: reqwest's `read_timeout` on
+  the download client, whose timer restarts on every frame that arrives, so a
+  dead connection still dies at `download_timeout_secs` while a slow live one
+  does not; and `notifications/cancelled`, which is how a host deliberately
+  stops a transfer. Every other method is bounded exactly as before -
+  abandoning one is what frees its dispatch slot and its cancellation-registry
+  entry. The exemption is a field on the tool registry rather than a method
+  name matched at the dispatch, so a tool added later has to state its answer
+  and cannot inherit one by omission.
 - **A cancelled download no longer leaves its temporary file behind** (#125).
   A transfer writes to a hidden `.data-gov-<pid>-<serial>.part` beside the
   destination and renames it into place at the end. Every error path removed
   that file before returning, but a cancelled download returns from none of
   them: the future is dropped where it stands and no code in the function body
-  runs. The MCP server does exactly that on two deliberate paths - the
-  per-request timeout, and `notifications/cancelled` - and nothing anywhere
+  runs. The MCP server does exactly that when a host sends
+  `notifications/cancelled`, and nothing anywhere
   swept the leftovers, so a user who cancelled a few large downloads
   accumulated hidden files in the download directory forever. The temporary
   file is now owned by a guard whose `Drop` removes it, disarmed once the

--- a/data-gov-mcp-server/src/concurrency_tests.rs
+++ b/data-gov-mcp-server/src/concurrency_tests.rs
@@ -17,11 +17,13 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
-use wiremock::MockServer;
+use wiremock::matchers::{method as wm_method, path as wm_path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::test_support::{
     INVALID_PARAMS, INVALID_REQUEST, METHOD_NOT_FOUND, PARSE_ERROR, Session, drive, error_code,
-    error_message, gated_server, gated_twice, test_server, test_server_with_gate,
+    error_message, gated_server, gated_twice, scratch_dir, test_server, test_server_with_gate,
+    timed_server,
 };
 
 /// The largest message the server accepts, in bytes, newline included.
@@ -37,6 +39,11 @@ const DISPATCH_SLOTS: usize = 256;
 /// download, no network, and no timing is involved.
 const SLOW_METHOD: &str = "data_gov.downloadResources";
 
+/// A tool method the per-request budget does bound, for the tests that check
+/// the budget still works. [`SLOW_METHOD`] cannot serve here: it is the one
+/// tool the registry marks exempt.
+const BOUNDED_METHOD: &str = "data_gov.search";
+
 /// A `tools/call` for the tool that maps to [`SLOW_METHOD`].
 fn slow_call(id: i64) -> Value {
     json!({
@@ -46,6 +53,19 @@ fn slow_call(id: i64) -> Value {
         "params": {
             "name": "data_gov_download_resources",
             "arguments": {"datasetId": "held-dataset"}
+        }
+    })
+}
+
+/// A `tools/call` for the tool that maps to [`BOUNDED_METHOD`].
+fn bounded_call(id: i64) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": {
+            "name": "data_gov_search",
+            "arguments": {"query": "held"}
         }
     })
 }
@@ -334,21 +354,26 @@ async fn concurrent_responses_are_written_as_whole_lines() {
 // The per-request timeout
 // ---------------------------------------------------------------------------
 
-/// A request that never finishes must not hold its slot forever. The gate is
-/// never released here, so the wait is unbounded and any finite timeout has to
-/// fire: the outcome does not depend on how long the test takes.
+/// A bounded request that never finishes must not hold its slot forever. The
+/// gate is never released here, so the wait is unbounded and any finite timeout
+/// has to fire: the outcome does not depend on how long the test takes.
 ///
 /// A tool that timed out reports it the way any other execution failure does,
 /// because the model can act on it - retry with fewer files, or a narrower
 /// filter.
+///
+/// The name says *bounded* because that is all this exercises. Exempting the
+/// download tool from the budget must not weaken the budget for anything else,
+/// and the mirror case is
+/// [`a_progressing_download_outlives_the_wall_clock_budget`].
 #[tokio::test]
-async fn a_tool_that_outruns_the_timeout_is_answered_with_a_tool_error() {
+async fn a_bounded_tool_that_outruns_the_timeout_is_answered_with_a_tool_error() {
     let mock = MockServer::start().await;
     let (server, _never_released) =
-        gated_server(&mock.uri(), SLOW_METHOD, Duration::from_millis(50));
+        gated_server(&mock.uri(), BOUNDED_METHOD, Duration::from_millis(50));
     let mut session = Session::start(server);
 
-    session.send(&slow_call(1)).await;
+    session.send(&bounded_call(1)).await;
 
     let response = session.next_response().await;
     assert_eq!(response.get("id"), Some(&json!(1)), "got: {response}");
@@ -361,7 +386,7 @@ async fn a_tool_that_outruns_the_timeout_is_answered_with_a_tool_error() {
         .as_str()
         .unwrap_or_default();
     assert!(
-        text.contains(SLOW_METHOD),
+        text.contains(BOUNDED_METHOD),
         "the message must name the call that was abandoned: {response}"
     );
 
@@ -403,6 +428,98 @@ async fn a_protocol_method_that_outruns_the_timeout_is_a_server_error() {
     }
 
     session.finish().await;
+}
+
+/// The product rule: work that is progressing is never killed by a wall-clock
+/// budget. `data_gov.downloadResources` is the one tool whose honest runtime is
+/// the size of a file over the width of a link, so the request budget cannot
+/// say anything true about it - a 222 MB dataset over a 250 KB/s link is a
+/// quarter of an hour of healthy transfer, and the old blanket bound killed it
+/// mid-flight after the user had already waited that long.
+///
+/// The transfer here is deliberately slower than the budget the server is
+/// given. Nothing about the numbers decides the outcome in the passing
+/// direction: with the exemption in place no wall clock applies at all, so a
+/// loaded machine cannot fail this. Without it the call is abandoned, because
+/// the response cannot arrive before the budget expires.
+///
+/// What still stops a download is unchanged and untested here: reqwest's
+/// `read_timeout` on the download client, which fires when no byte arrives for
+/// `download_timeout_secs`, and `notifications/cancelled`.
+#[tokio::test]
+async fn a_progressing_download_outlives_the_wall_clock_budget() {
+    /// Shorter than the transfer, so a bounded download cannot survive it.
+    const REQUEST_BUDGET: Duration = Duration::from_millis(50);
+    /// Longer than the budget, so the transfer provably outruns it.
+    const TRANSFER_TIME: Duration = Duration::from_millis(400);
+
+    let mock = MockServer::start().await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/api/dataset/slow-but-alive"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "results": [{
+                "slug": "slow-but-alive",
+                "title": "Slow But Alive",
+                "dcat": {
+                    "@type": "dcat:Dataset",
+                    "title": "Slow But Alive",
+                    "distribution": [{
+                        "@type": "dcat:Distribution",
+                        "title": "bulk",
+                        "downloadURL": format!("{}/bulk.csv", mock.uri()),
+                        "mediaType": "text/csv"
+                    }]
+                }
+            }],
+            "sort": "relevance"
+        })))
+        .mount(&mock)
+        .await;
+    Mock::given(wm_method("GET"))
+        .and(wm_path("/bulk.csv"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string("a,b\n1,2\n")
+                .set_delay(TRANSFER_TIME),
+        )
+        .mount(&mock)
+        .await;
+
+    let server = timed_server(&mock.uri(), REQUEST_BUDGET);
+    let output_dir = scratch_dir("slow-but-alive");
+
+    let value = server
+        .dispatch(
+            "tools/call",
+            Some(json!({
+                "name": "data_gov_download_resources",
+                "arguments": {
+                    "datasetId": "slow-but-alive",
+                    "outputDir": output_dir.to_string_lossy(),
+                    "datasetSubdirectory": false
+                }
+            })),
+        )
+        .await
+        .expect("a download is a tool result, not a JSON-RPC error");
+
+    let _ = std::fs::remove_dir_all(&output_dir);
+
+    assert_eq!(
+        value["isError"],
+        json!(false),
+        "a transfer that was progressing must not be abandoned: {value}"
+    );
+    let summary = &value["structuredContent"];
+    assert_eq!(
+        summary["successfulCount"],
+        json!(1),
+        "the file must actually have arrived: {value}"
+    );
+    assert_eq!(
+        summary["downloads"][0]["status"], "success",
+        "the file must actually have arrived: {value}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/data-gov-mcp-server/src/dispatch_tests.rs
+++ b/data-gov-mcp-server/src/dispatch_tests.rs
@@ -16,7 +16,7 @@ use wiremock::matchers::{method as wm_method, path as wm_path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use crate::test_support::{
-    CURRENT_MCP_REVISION, PUBLISHED_MCP_REVISIONS, search_body, test_server,
+    CURRENT_MCP_REVISION, PUBLISHED_MCP_REVISIONS, scratch_dir, search_body, test_server,
 };
 use crate::types::{SUPPORTED_PROTOCOL_VERSIONS, ServerError};
 
@@ -934,18 +934,6 @@ async fn a_blank_format_filter_does_not_shift_the_unavailable_format_report() {
 // ---------------------------------------------------------------------------
 // A download that downloaded nothing
 // ---------------------------------------------------------------------------
-
-/// A scratch directory under the system temp dir, removed first so a previous
-/// run cannot influence this one. The caller removes it when finished.
-fn scratch_dir(name: &str) -> std::path::PathBuf {
-    let dir = std::env::temp_dir().join(format!(
-        "data-gov-mcp-{name}-{}-{:?}",
-        std::process::id(),
-        std::thread::current().id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    dir
-}
 
 /// A tool that downloaded none of the files it was asked for did not succeed.
 ///

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -9,7 +9,8 @@ use tokio::time::timeout;
 
 use crate::server::DataGovMcpServer;
 use crate::tools::{
-    ListToolsResult, ToolResponse, find_tool_spec, find_tool_spec_by_method, tool_descriptors,
+    ListToolsResult, ToolResponse, WallClockBound, find_tool_spec, find_tool_spec_by_method,
+    tool_descriptors, wall_clock_bound,
 };
 use crate::types::*;
 
@@ -73,11 +74,23 @@ impl DataGovMcpServer {
     /// execution failure, because a model can act on it; a timed-out protocol
     /// method has no tool result to travel in and stays a JSON-RPC error.
     /// [`ServerError::is_tool_execution_failure`] makes that split.
+    ///
+    /// A tool the registry marks [`WallClockBound::Exempt`] runs without it.
+    /// Elapsed time says nothing true about a transfer, so a budget that fits
+    /// one link kills a healthy download on a slower one; what still stops
+    /// such a tool is its own stall bound and `notifications/cancelled`. The
+    /// answer is read from the tool registry rather than matched on the method
+    /// name here, so a tool added later has to declare it - see
+    /// [`crate::tools::ToolSpec::wall_clock`].
     async fn invoke_method(
         &self,
         method: &str,
         params: Option<Value>,
     ) -> Result<Value, ServerError> {
+        if wall_clock_bound(method) == WallClockBound::Exempt {
+            return self.run_method(method, params).await;
+        }
+
         match timeout(self.request_timeout, self.run_method(method, params)).await {
             Ok(result) => result,
             Err(_elapsed) => {

--- a/data-gov-mcp-server/src/server.rs
+++ b/data-gov-mcp-server/src/server.rs
@@ -20,10 +20,21 @@ pub(crate) const CANCELLED_NOTIFICATION: &str = "notifications/cancelled";
 
 /// How long one request may run before the server abandons it.
 ///
-/// Downloads set the floor: `data_gov.downloadResources` allows 300 seconds
-/// per file with three in flight, so a large dataset legitimately takes
-/// minutes. This is the outer bound that stops a hung upstream holding a
-/// request, and its slot in the cancellation registry, open forever.
+/// Applies to every method except a tool the registry marks
+/// [`crate::tools::WallClockBound::Exempt`] - today only
+/// `data_gov.downloadResources`. What is left answers from memory or from a
+/// single catalog call, each of which carries its own 30-second bound, so a
+/// request still running after this has gone wrong rather than gone slowly.
+/// Abandoning it is what stops a hung upstream holding a request, and its slot
+/// in the cancellation registry, open forever.
+///
+/// The figure is deliberately far above anything a bounded method should need,
+/// because it is not operator tunable and the cost of setting it too low is a
+/// request killed while it was working. It is not a download budget: a
+/// transfer's honest runtime is the size of a file over the width of a link,
+/// which no constant here can predict, so downloads are exempt and are bounded
+/// instead by reqwest's `read_timeout` on the download client - which restarts
+/// on every frame that arrives - and by `notifications/cancelled`.
 pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(900);
 
 /// Responses buffered between the dispatch tasks and the writer.
@@ -49,7 +60,10 @@ const RESPONSE_QUEUE_DEPTH: usize = 64;
 /// `notifications/cancelled` queued behind the request that saturated it waits
 /// too. That is inherent to backpressure on a single ordered stream - the
 /// cancellation cannot be read without reading the line in front of it - and
-/// [`DEFAULT_REQUEST_TIMEOUT`] is the backstop that always frees a slot.
+/// [`DEFAULT_REQUEST_TIMEOUT`] is the backstop that frees the slot of every
+/// request it bounds. A download is deliberately not one of them: its slot is
+/// given up when the transfer finishes, when its own stall bound fires, or on
+/// a cancellation, never on elapsed time.
 const MAX_CONCURRENT_DISPATCHES: usize = 256;
 
 /// The largest message the server will accept, in bytes, newline included.

--- a/data-gov-mcp-server/src/test_support.rs
+++ b/data-gov-mcp-server/src/test_support.rs
@@ -127,6 +127,29 @@ pub(crate) fn test_server_with_gate(
     gated_server(mock_uri, method, DEFAULT_REQUEST_TIMEOUT)
 }
 
+/// A server that abandons a request after `request_timeout` and gates nothing.
+///
+/// A gate holds a method before it does any work, which is exactly wrong for a
+/// test that has to watch real work run past the budget. This door leaves the
+/// handler free to run and moves only the budget.
+pub(crate) fn timed_server(mock_uri: &str, request_timeout: Duration) -> Arc<DataGovMcpServer> {
+    let mut server = test_server(mock_uri);
+    server.request_timeout = request_timeout;
+    Arc::new(server)
+}
+
+/// A scratch directory under the system temp dir, removed first so a previous
+/// run cannot influence this one. The caller removes it when finished.
+pub(crate) fn scratch_dir(name: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "data-gov-mcp-{name}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    dir
+}
+
 /// A gated server that abandons a request after `request_timeout`.
 pub(crate) fn gated_server(
     mock_uri: &str,

--- a/data-gov-mcp-server/src/tools.rs
+++ b/data-gov-mcp-server/src/tools.rs
@@ -4,6 +4,29 @@ use serde::Serialize;
 use serde_json::{Value, json};
 use std::sync::LazyLock;
 
+/// Whether the server's per-request wall-clock budget bounds a tool.
+///
+/// The budget answers a question about elapsed time, and elapsed time only
+/// means something for work whose honest duration is short. For a transfer it
+/// means nothing: the same file is a second on one link and an hour on
+/// another, so any figure picked here kills a healthy download somewhere.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub(crate) enum WallClockBound {
+    /// The request budget applies. The tool is expected to finish promptly,
+    /// and abandoning it is what frees its dispatch slot and its entry in the
+    /// cancellation registry.
+    Applies,
+    /// The request budget never applies, whatever it is set to.
+    ///
+    /// Only for a tool that streams bulk bytes, where progress rather than
+    /// elapsed time says whether it is healthy. Such a tool must carry its own
+    /// stall bound - for downloads, reqwest's `read_timeout`, which restarts
+    /// on every frame that arrives and therefore kills a dead connection
+    /// without touching a live slow one - and must remain stoppable by
+    /// `notifications/cancelled`.
+    Exempt,
+}
+
 /// Definition of a single MCP tool linking its public name to a server method.
 #[derive(Debug, Serialize)]
 pub(crate) struct ToolSpec {
@@ -11,6 +34,15 @@ pub(crate) struct ToolSpec {
     pub method_name: &'static str,
     pub description: &'static str,
     pub input_schema: Value,
+    /// Whether [`crate::server::DEFAULT_REQUEST_TIMEOUT`] bounds this tool.
+    ///
+    /// The property lives on the spec rather than beside the dispatch because
+    /// this registry is the one place a tool must be declared, and Rust makes
+    /// a struct literal name every field: a tool added later has to state its
+    /// answer and cannot inherit one by omission. A `match` on the method name
+    /// at the dispatch would give a new tool the default silently, which is
+    /// the accident this is here to prevent (#131).
+    pub wall_clock: WallClockBound,
 }
 
 /// Result payload for `tools/list`.
@@ -135,6 +167,15 @@ pub(crate) fn find_tool_spec_by_method(method: &str) -> Option<&'static ToolSpec
     TOOL_SPECS.iter().find(|spec| spec.method_name == method)
 }
 
+/// Whether the per-request wall-clock budget bounds `method`.
+///
+/// A method that is not a tool - `initialize`, `ping`, `tools/list` - is always
+/// bounded. Each answers from memory in microseconds, so a budget can only ever
+/// catch one that has gone wrong.
+pub(crate) fn wall_clock_bound(method: &str) -> WallClockBound {
+    find_tool_spec_by_method(method).map_or(WallClockBound::Applies, |spec| spec.wall_clock)
+}
+
 /// All registered tool specifications, lazily initialized.
 pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
     vec![
@@ -174,6 +215,7 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
                 },
                 "additionalProperties": false
             }),
+            wall_clock: WallClockBound::Applies,
         },
         ToolSpec {
             tool_name: "data_gov_dataset",
@@ -191,6 +233,7 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
                 "required": ["slug"],
                 "additionalProperties": false
             }),
+            wall_clock: WallClockBound::Applies,
         },
         ToolSpec {
             tool_name: "data_gov_autocomplete_datasets",
@@ -206,6 +249,7 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
                 "required": ["partial"],
                 "additionalProperties": false
             }),
+            wall_clock: WallClockBound::Applies,
         },
         ToolSpec {
             tool_name: "data_gov_list_organizations",
@@ -218,6 +262,7 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
                 },
                 "additionalProperties": false
             }),
+            wall_clock: WallClockBound::Applies,
         },
         ToolSpec {
             tool_name: "data_gov_download_resources",
@@ -258,6 +303,12 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
                 "required": ["datasetId"],
                 "additionalProperties": false
             }),
+            // The one exempt tool. Its runtime is the size of a file over
+            // the width of a link, so no wall-clock figure can tell a healthy
+            // transfer from a stuck one. reqwest's `read_timeout` on the
+            // download client can, and `notifications/cancelled` is how a
+            // host asks for one to stop.
+            wall_clock: WallClockBound::Exempt,
         },
     ]
 });
@@ -336,6 +387,47 @@ mod tests {
     #[test]
     fn find_tool_spec_by_method_unknown_returns_none() {
         assert!(find_tool_spec_by_method("nonexistent.method").is_none());
+    }
+
+    /// Exemption is the answer that is dangerous to get wrong: an exempt tool
+    /// holds its dispatch slot and its cancellation-registry entry for as long
+    /// as it runs, with nothing but its own stall bound to end it. The set is
+    /// written out literally rather than derived from the registry, so a tool
+    /// that joins it has to change this line and say why.
+    #[test]
+    fn only_the_download_tool_is_exempt_from_the_wall_clock_budget() {
+        let exempt: Vec<&str> = TOOL_SPECS
+            .iter()
+            .filter(|spec| spec.wall_clock == WallClockBound::Exempt)
+            .map(|spec| spec.method_name)
+            .collect();
+        assert_eq!(
+            exempt,
+            vec!["data_gov.downloadResources"],
+            "only a tool that streams bulk bytes may be exempt; give a new one \
+             its own stall bound before adding it here"
+        );
+    }
+
+    /// Everything outside the registry is bounded, including a method that
+    /// does not exist. A default of `Exempt` would let an unknown method run
+    /// unbounded, which is the opposite of what a budget is for.
+    #[test]
+    fn a_method_outside_the_tool_registry_is_wall_clock_bounded() {
+        for method in [
+            "initialize",
+            "notifications/initialized",
+            "ping",
+            "tools/list",
+            "tools/call",
+            "nonexistent.method",
+        ] {
+            assert_eq!(
+                wall_clock_bound(method),
+                WallClockBound::Applies,
+                "`{method}` is not a tool and must stay bounded"
+            );
+        }
     }
 
     /// MCP 2025-11-25, server/tools: structured content "is returned as a JSON

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -62,10 +62,11 @@ struct DownloadJob<'a> {
 /// `perform_download` discards its temporary file on every path it returns an
 /// error from, but a cancelled download returns from none of them: the future
 /// is dropped where it stands, and no code in the function body runs. The MCP
-/// server does exactly that on two deliberate paths - the per-request timeout,
-/// and `notifications/cancelled` - so without this a user who cancels a few
-/// large downloads accumulates hidden `.part` files in the download directory
-/// that nothing ever sweeps (#125).
+/// server does exactly that when a host sends `notifications/cancelled`, which
+/// is the one deliberate path that drops a transfer - the per-request timeout
+/// no longer bounds a download (#131) - so without this a user who cancels a
+/// few large downloads accumulates hidden `.part` files in the download
+/// directory that nothing ever sweeps (#125).
 ///
 /// Call [`PartialFileGuard::keep`] once the file has been renamed onto the
 /// destination, so a finished download does not have its own result removed.


### PR DESCRIPTION
Closes findings from the independent review of the 0.5.0 release-review fixes.

Gate green in the authoring worktree; the reviewer re-verified by mutation on a clean checkout.

Detail is in the commit body.