### PR TITLE
fix(data-gov): send library diagnostics to tracing, and correct two false rustdoc claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .worktrees
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,6 +282,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All dependencies refreshed to their latest semver-compatible releases.
   `rustyline` 17 → 18 is deliberately **not** included; it is a major bump
   under the whole REPL and is tracked separately.
+- **The `data-gov` library reports through `tracing`, not stderr.** Three
+  places in the library wrote a line straight to the terminal of whatever
+  program had linked it: two reporting a `.part` file that could not be
+  removed, and one reporting that the working directory could not be read,
+  on the path that chooses a download directory - which runs once per
+  download call, so it could repeat. An
+  embedder could not route, level or silence any of them, and a program that
+  collects `tracing` lost them entirely while getting unattributed noise on
+  its stderr. They are now `tracing::warn!` with structured fields. `tracing`
+  is a new dependency of `data-gov`, the facade only: a consumer that installs
+  no subscriber sees nothing and pays nothing, and the crate was already in
+  the lockfile at the same version through `data-gov-mcp-server`.
+  `just check-print-macros` now scans the library crates too, so the next bare
+  `eprintln!` fails the build rather than shipping.
 
 ### Security
 - **Credentials in a `base_url` are masked wherever it is displayed** (#86). A
@@ -409,12 +423,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is not an error, so a command that succeeded still exits 0 - but a command
   that failed still exits non-zero, and destructors still run, neither of
   which survives a `process::exit` taken at the first broken write. The cost
-  is that `data-gov list organizations | head -5` now finishes fetching
-  rather than stopping at the fifth line. Any other write error stays as loud
-  as it was. The usual `SIGPIPE` fix needs `unsafe`, which this project
-  forbids.
+  is that a command keeps working after its reader leaves:
+  `data-gov download <slug> | head -1` now carries the transfer through to
+  the end, where before it died on the line announcing the download - which
+  is printed before any of the file is written - and so transferred nothing.
+  Any other write error stays as loud as it was. The usual `SIGPIPE` fix
+  needs `unsafe`, which this project forbids.
   `just check-print-macros` now fails the build if a bare `println!` returns
-  to the CLI.
+  to the CLI or to a library crate.
 - **`DataGovError::sanitized_message` no longer leaks the paths it promises to
   remove** (#59). It documented itself as stripping filesystem paths, had no
   test and no caller, and stripped only tokens that began with `/` or `./`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
  "url",
  "wiremock",
 ]

--- a/data-gov/Cargo.toml
+++ b/data-gov/Cargo.toml
@@ -34,6 +34,14 @@ indicatif = { version = "0.18.1", features = ["tokio"] }
 url = "2.5"
 # Cross-platform directories
 dirs = "6.0"
+# Library diagnostics (src/client.rs, src/config.rs). A library linked into
+# somebody else's program must not write to their terminal: a bare stderr line
+# cannot be routed, levelled or silenced by the embedder, and is lost outright
+# to one that collects `tracing`. This is the facade only - no subscriber - so
+# a consumer that installs none pays nothing. Already in the lockfile at the
+# same version through data-gov-mcp-server, so it adds no new transitive
+# dependency.
+tracing = "0.1"
 # Configuration file (src/config/file.rs). The standard library has no TOML
 # parser and no derive-based deserialization, and config.toml is a data shape
 # with a known key set that CLAUDE.md requires be modelled as a struct rather

--- a/data-gov/README.md
+++ b/data-gov/README.md
@@ -365,6 +365,20 @@ let config = resolved.into_config();
 file, no home directory — which is what makes the chain testable without
 mutating process state.
 
+## Logging
+
+The library never writes to your process's terminal. Progress and per-file
+download events reach you through the `StatusReporter` you install on the
+config; diagnostics - a `.part` file that could not be removed, a working
+directory that could not be read - go out as `tracing` warnings with
+structured fields. Install any `tracing` subscriber to see them:
+
+```rust
+tracing_subscriber::fmt::init();
+```
+
+With no subscriber installed, nothing is emitted and nothing is printed.
+
 ## Cargo features
 
 | Feature       | Default | Effect                                             |

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -106,9 +106,10 @@ impl Drop for PartialFileGuard {
             Ok(()) => {}
             // Already gone: an error path discarded it before returning.
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => eprintln!(
-                "data-gov: could not remove the unfinished download {}: {err}",
-                self.path.display()
+            Err(err) => tracing::warn!(
+                path = %self.path.display(),
+                error = %err,
+                "could not remove the unfinished download"
             ),
         }
     }
@@ -137,15 +138,27 @@ impl DataGovClient {
     /// # Errors
     ///
     /// Returns [`DataGovError::ConfigError`] when `max_concurrent_downloads`
-    /// or `download_timeout_secs` is zero. Both are `pub` fields on a struct
-    /// that is not `#[non_exhaustive]`, so a struct literal can reach either
-    /// one without the builder that would otherwise clamp it -- and neither
-    /// zero has a useful meaning: a zero-permit semaphore never closes
-    /// (#73), and a zero-second connect/read timeout fails every download
-    /// immediately, in a way that reads as a network problem rather than a
-    /// configuration one (#107). Rejecting here, rather than clamping, means
-    /// the caller finds out at construction instead of at the first silent
-    /// failure.
+    /// or `download_timeout_secs` is zero. Neither zero has a useful meaning:
+    /// a zero-permit semaphore never closes (#73), and a zero-second
+    /// connect/read timeout fails every download immediately, in a way that
+    /// reads as a network problem rather than a configuration one (#107).
+    ///
+    /// Every route to a configuration ends here, and none of them clamps on
+    /// the way. The fields are `pub` on a struct that is not
+    /// `#[non_exhaustive]`, so a struct literal arrives at this check
+    /// directly; and
+    /// [`with_max_concurrent_downloads`](crate::DataGovConfig::with_max_concurrent_downloads)
+    /// and
+    /// [`with_download_timeout`](crate::DataGovConfig::with_download_timeout)
+    /// store what they were given, zero included, so the builder is a
+    /// convenience rather than a second gate to get past. A zero therefore
+    /// always surfaces as an error naming the setting, at construction -
+    /// never as a substituted value the caller never chose, and never as a
+    /// download that hangs or fails with nothing to explain it.
+    ///
+    /// Returns [`DataGovError::HttpError`] if the underlying HTTP client
+    /// cannot be built - a missing or unusable TLS backend is the realistic
+    /// cause.
     pub fn with_config(config: DataGovConfig) -> Result<Self> {
         if config.max_concurrent_downloads == 0 {
             return Err(DataGovError::config_error(
@@ -871,14 +884,16 @@ impl DataGovClient {
     /// Best effort by design: the transfer has already failed, and being
     /// unable to tidy up is not a second failure to report to the caller. It
     /// is still worth saying out loud, because the alternative is a `.part`
-    /// file nobody can account for.
+    /// file nobody can account for - so it goes out as a `tracing` warning,
+    /// which an embedder can route, rather than to a stderr it does not own.
     async fn discard_partial(temp_path: &Path) {
         match tokio::fs::remove_file(temp_path).await {
             Ok(()) => {}
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-            Err(err) => eprintln!(
-                "data-gov: could not remove the unfinished download {}: {err}",
-                temp_path.display()
+            Err(err) => tracing::warn!(
+                path = %temp_path.display(),
+                error = %err,
+                "could not remove the unfinished download"
             ),
         }
     }
@@ -1283,6 +1298,27 @@ mod tests {
             DataGovError::ConfigError { message } => {
                 assert!(
                     message.contains("max_concurrent_downloads"),
+                    "the error must name the field, got: {message}"
+                );
+            }
+            other => panic!("expected ConfigError, got {other:?}"),
+        }
+    }
+
+    /// The rustdoc on `with_config` tells a consumer that no builder is a
+    /// way round the zero check, and names this setter alongside the
+    /// concurrency one. The concurrency half is pinned above; this pins the
+    /// half that was only ever asserted in prose.
+    #[test]
+    fn a_zero_download_timeout_from_the_builder_reaches_the_named_error() {
+        let config = crate::config::DataGovConfig::new().with_download_timeout(0);
+
+        let err = DataGovClient::with_config(config)
+            .expect_err("a zero from the builder must be refused, not silently become 1");
+        match err {
+            DataGovError::ConfigError { message } => {
+                assert!(
+                    message.contains("download_timeout_secs"),
                     "the error must name the field, got: {message}"
                 );
             }

--- a/data-gov/src/config.rs
+++ b/data-gov/src/config.rs
@@ -200,7 +200,10 @@ impl DataGovConfig {
     /// in [`OperatingMode::CommandLine`].
     ///
     /// When the working directory cannot be read, this falls back to `"."` and
-    /// says so on stderr. It never fails silently (#53).
+    /// reports the reason as a `tracing` warning. It never fails silently
+    /// (#53). A download that names no directory of its own comes through
+    /// here, so the same warning can repeat: it goes somewhere an embedder
+    /// can filter, rather than onto a stderr the library does not own.
     pub fn get_base_download_dir(&self) -> PathBuf {
         if let Some(dir) = &self.base_download_dir {
             return dir.clone();
@@ -208,7 +211,11 @@ impl DataGovConfig {
 
         let (dir, warning) = default_download_dir_for(&self.mode, std::env::current_dir());
         if let Some(warning) = warning {
-            eprintln!("Warning: {warning}");
+            tracing::warn!(
+                warning = %warning,
+                fallback = %dir.display(),
+                "could not settle the download directory from the working directory"
+            );
         }
         dir
     }

--- a/data-gov/tools/cli/ui/output.rs
+++ b/data-gov/tools/cli/ui/output.rs
@@ -31,10 +31,12 @@
 //!   finishes and reports as it would have.
 //!
 //! The cost of not exiting is that a long command keeps working after its
-//! reader leaves: `data-gov list organizations | head -5` now fetches every
-//! page rather than stopping at the fifth line. That is the price of an
-//! honest exit code, and it is bounded by what the command was going to do
-//! anyway.
+//! reader leaves: `data-gov download <slug> | head -1` now carries the
+//! transfer through to the end. Before, it died on the next line it wrote
+//! after `head` had gone - the line announcing the download, which is
+//! printed before any of the file is written - so the transfer never
+//! happened at all. That is the price of an honest exit code, and it is
+//! bounded by what the command was going to do anyway.
 //!
 //! Any other write error keeps the old loud behaviour, so a genuinely
 //! broken stdout is still not silent.

--- a/scripts/check-print-macros.py
+++ b/scripts/check-print-macros.py
@@ -1,21 +1,35 @@
 #!/usr/bin/env python3
-"""Fail if the CLI writes user-facing output with `println!` or `eprintln!`.
+"""Fail if the CLI or a library crate prints with `println!` or `eprintln!`.
 
-`println!` panics when the write fails, so piping the CLI into a reader that
-quits early - `data-gov list organizations | head -5` - killed the process with
-exit 101 and a backtrace note over ordinary Unix usage (#115). The fix routes
-every user-facing line through `outln!` and `errln!` in
+Two separate defects, one matcher.
+
+**The CLI.** `println!` panics when the write fails, so piping the CLI into a
+reader that quits early - `data-gov list organizations | head -5` - killed the
+process with exit 101 and a backtrace note over ordinary Unix usage (#115). The
+fix routes every user-facing line through `outln!` and `errln!` in
 `data-gov/tools/cli/ui/output.rs`, which recognise a closed pipe and stop
 quietly.
 
-That fix holds only while it is complete. One `println!` added later reopens
-the defect on whichever command it prints from, and nothing else would notice:
-the code compiles, the tests pass, and the crash appears only when somebody
-pipes that particular command into `head`. So the absence of the bare macros is
+**The library crates.** A library does not own the process it is linked into. A
+line written straight to stderr from `data-gov` reaches an embedder as
+unattributed noise it cannot route, level, silence or capture, and it is lost
+outright to a program that collects `tracing`. Library diagnostics therefore go
+through `tracing` (CLAUDE.md, "Logging discipline"); user-facing progress goes
+to the embedder through `data_gov::ui::StatusReporter`. None of the three
+library crates prints.
+
+Both fixes hold only while they are complete. One `println!` added later
+reopens the defect where it was added, and nothing else would notice: the code
+compiles, the tests pass, and the CLI crash appears only when somebody pipes
+that particular command into `head`. So the absence of the bare macros is
 checked here rather than remembered.
 
+`data-gov-mcp-server` is deliberately not scanned. It is a binary with no
+`lib.rs`, nothing embeds it, and it writes its startup warnings to stderr on
+purpose: stdout carries the JSON-RPC stream and may hold nothing else.
+
 Comment lines are exempt, because `output.rs` documents the macros it replaces
-by name.
+by name and the client crates print in their rustdoc examples.
 
 Run with --self-test to check the matcher itself against the cases below. The
 gate runs that first, so a change that breaks the matcher fails immediately
@@ -32,9 +46,39 @@ import sys
 # lookbehind keeps `my_println!` and similar from matching on their tail.
 PRINT_MACRO_RE = re.compile(r"(?<!\w)e?print(?:ln)?!")
 
-# Only the CLI binary is covered. The library crates do not print to the
-# user's terminal; they report through `data_gov::ui::StatusReporter`.
-SCANNED_PREFIX = "data-gov/tools/cli/"
+# Each scope is a path prefix, the name used in messages, and the advice a
+# violation there gets - which differs, because the two defects have different
+# fixes. `data-gov/src/` is the library half of the crate whose binary lives
+# under `data-gov/tools/cli/`.
+SCOPES: list[tuple[str, str, str]] = [
+    (
+        "data-gov/tools/cli/",
+        "CLI",
+        "Use `outln!` and `errln!` from `data-gov/tools/cli/ui/output.rs`, "
+        "which stop quietly when the reader closes the pipe (#115).",
+    ),
+    (
+        "data-gov/src/",
+        "data-gov",
+        "A library must not write to the embedder's terminal. Use "
+        "`tracing::warn!` (or the level the message deserves) so the "
+        "embedder can route it.",
+    ),
+    (
+        "data-gov-catalog/src/",
+        "data-gov-catalog",
+        "A library must not write to the embedder's terminal. Use "
+        "`tracing::warn!` (or the level the message deserves) so the "
+        "embedder can route it.",
+    ),
+    (
+        "data-gov-ckan/src/",
+        "data-gov-ckan",
+        "A library must not write to the embedder's terminal. Use "
+        "`tracing::warn!` (or the level the message deserves) so the "
+        "embedder can route it.",
+    ),
+]
 
 SELF_TEST_CASES: list[tuple[str, bool]] = [
     # (line, is it a violation?)
@@ -54,6 +98,10 @@ SELF_TEST_CASES: list[tuple[str, bool]] = [
     # Identifiers that merely end in a covered name.
     ('    my_println!("x");', False),
     ('    sprint!("x");', False),
+    # What library code says instead, and the rustdoc examples that show a
+    # consumer printing - which are comment lines and stay exempt.
+    ('    tracing::warn!(path = %p, "could not remove it");', False),
+    ('/// println!("{} datasets", results.count.unwrap_or(0));', False),
 ]
 
 
@@ -85,9 +133,9 @@ def self_test() -> int:
     return 0
 
 
-def tracked_cli_sources() -> list[str]:
+def tracked_sources(prefix: str) -> list[str]:
     out = subprocess.run(
-        ["git", "ls-files", f"{SCANNED_PREFIX}*.rs"],
+        ["git", "ls-files", f"{prefix}*.rs"],
         capture_output=True,
         text=True,
         check=True,
@@ -95,19 +143,22 @@ def tracked_cli_sources() -> list[str]:
     return [path for path in out.stdout.splitlines() if path]
 
 
-def main() -> int:
-    if "--self-test" in sys.argv:
-        return self_test()
+def scan(prefix: str, label: str, advice: str) -> tuple[int, int]:
+    """Scan one scope. Returns (files scanned, violations found).
 
-    sources = tracked_cli_sources()
+    An empty scope is itself a violation: the code moved and this check is
+    silently guarding nothing, which is the failure mode that lets the
+    defect back in unnoticed.
+    """
+    sources = tracked_sources(prefix)
     if not sources:
         print(
-            f"::error::no tracked .rs files under {SCANNED_PREFIX}. The CLI "
+            f"::error::no tracked .rs files under {prefix}. The {label} code "
             "moved, so this check is scanning nothing - point it at the new "
             "location.",
             file=sys.stderr,
         )
-        return 1
+        return (0, 1)
 
     findings = 0
     for path in sources:
@@ -119,15 +170,27 @@ def main() -> int:
 
     if findings:
         print(
-            f"\n{findings} bare printing macro(s) above. `println!` and "
-            "`eprintln!` panic when the reader closes the pipe (#115). Use "
-            "`outln!` and `errln!` from `data-gov/tools/cli/ui/output.rs` "
-            "instead.",
+            f"\n{findings} bare printing macro(s) in {label}. {advice}\n",
             file=sys.stderr,
         )
+    return (len(sources), findings)
+
+
+def main() -> int:
+    if "--self-test" in sys.argv:
+        return self_test()
+
+    scanned = 0
+    findings = 0
+    for prefix, label, advice in SCOPES:
+        files, bad = scan(prefix, label, advice)
+        scanned += files
+        findings += bad
+
+    if findings:
         return 1
 
-    print(f"check-print-macros: {len(sources)} CLI source file(s) clean.")
+    print(f"check-print-macros: {scanned} source file(s) clean.")
     return 0
 
 


### PR DESCRIPTION
Closes findings from the independent review of the 0.5.0 release-review fixes.

Gate green in the authoring worktree; the reviewer re-verified by mutation on a clean checkout.

Detail is in the commit body.