### PR TITLE
test(release): make the publish-helper tests fail when the code they name is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,6 +574,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guard on it. Each needle is now a phrase only the script under test can
   produce, and the wait case is asserted from both sides, so collapsing either
   branch into the other fails a test.
+- **A 200 that is not the index file no longer reads as "not published"**.
+  `index-has.sh` concluded absent from any 200 whose body did not list the
+  version, including a captive portal or a proxy sign-in page that lists no
+  version at all - and absent is the answer that means publish. The body must
+  now carry `"name":"<crate>"`, the field every sparse-index line opens with,
+  before absent is concluded. Without it the answer is unknown, which stops
+  the job.
 - **A filtered run of the helper tests no longer reads another case's
   output.** Each follow-up assertion filtered on its own name, which differs
   from the name of the run whose capture it reads, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,6 +563,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of which the live service can be asked for - and asserts that `cargo` is
   never invoked when the index state is unknown. The workflow's behaviour,
   publish order and dependency waits are unchanged.
+- **The release-helper tests now fail when the helper they name stops
+  working.** Two of them could not. Each asserted on "could not be reached", a
+  phrase `index-has.sh` prints to stderr itself, and the capture holds the
+  whole subtree's output - so the needle was present whatever the script under
+  test said. Proved by mutation: replacing `publish-crate.sh`'s refusal message
+  with `echo "::error::MUTATED"` left the suite green, and so did collapsing
+  `wait-for-crate.sh`'s "the index could not be reached" into "not yet
+  visible" - the exact distinction its own test is named for, and the only
+  guard on it. Each needle is now a phrase only the script under test can
+  produce, and the wait case is asserted from both sides, so collapsing either
+  branch into the other fails a test.
+- **A filtered run of the helper tests no longer reads another case's
+  output.** Each follow-up assertion filtered on its own name, which differs
+  from the name of the run whose capture it reads, so
+  `test-release-helpers.sh publish_names` skipped the run and then grepped a
+  file that was missing or left over from an earlier case - a stale pass in
+  the second instance. Assertions now inherit the filter decision of the run
+  they inspect and say when they are refused, and a filter that selects no run
+  fails instead of reporting an empty pass. The suite also caps the per-probe
+  timeout, so the unreachable-index cases cannot stall the gate for minutes
+  behind a host that drops packets instead of refusing them.
 - **The index wait now has a ceiling it actually keeps**. `wait-for-crate.sh`
   reported a bound of `attempts * delay`, but its `curl` had no timeout at
   all, so a connection that hung stalled the release job with no limit. Each

--- a/scripts/release/index-has.sh
+++ b/scripts/release/index-has.sh
@@ -9,9 +9,11 @@
 #   exit 0  published   - the index answered and lists this version
 #   exit 1  absent      - the index answered and does not list this version,
 #                         or has never heard of the crate (404)
-#   exit 2  unknown     - the index could not be reached, or answered with
-#                         something other than 200 or 404, and kept doing so
-#                         across every retry. The caller must stop.
+#   exit 2  unknown     - the index could not be reached, answered with
+#                         something other than 200 or 404, or answered 200
+#                         with a body that is not this crate's index file,
+#                         and kept doing so across every retry. The caller
+#                         must stop.
 #
 # The status comes from curl's -w '%{http_code}', not from curl's exit code
 # alone: a 500, a reset connection and a genuine 404 are one single non-zero
@@ -65,6 +67,12 @@ curl_error="${work}/curl-error"
 # answer for it.
 needle="\"vers\":\"${version}\""
 
+# Every line of a sparse-index file carries the crate name, so a 200 without
+# it is not this crate's index file: a captive portal, a proxy sign-in page,
+# or a CDN error page served with 200. Absent this check, such a body reads as
+# "the version is not listed", which is the one answer that means publish.
+crate_needle="\"name\":\"${name}\""
+
 reason="no probe was attempted"
 for attempt in $(seq 1 "$attempts"); do
   curl_status=0
@@ -78,10 +86,13 @@ for attempt in $(seq 1 "$attempts"); do
   else
     case "$http_code" in
       200)
-        if grep -qF -- "$needle" "$body"; then
+        if ! grep -qF -- "$crate_needle" "$body"; then
+          reason="the index answered HTTP 200 with a body that is not the index file for ${name}"
+        elif grep -qF -- "$needle" "$body"; then
           exit "$EXIT_PUBLISHED"
+        else
+          exit "$EXIT_ABSENT"
         fi
-        exit "$EXIT_ABSENT"
         ;;
       404)
         exit "$EXIT_ABSENT"

--- a/scripts/release/test-release-helpers.sh
+++ b/scripts/release/test-release-helpers.sh
@@ -210,6 +210,13 @@ cat > "$tmp/index-regex-trap.txt" <<'BODY'
 {"name":"data-gov-ckan","vers":"0X5X0","deps":[],"cksum":"2222222222222222222222222222222222222222222222222222222222222222","features":{},"yanked":false}
 BODY
 
+# A 200 that is not an index file at all. A captive portal, a proxy sign-in
+# page, or a CDN error page served with 200 all look like this.
+cat > "$tmp/index-interception.txt" <<'BODY'
+<html><head><title>Sign in</title></head>
+<body><h1>Sign in to continue</h1></body></html>
+BODY
+
 # Keep the retries and the polling short. The defaults are tuned for a real
 # release; a test must not spend minutes proving a guard fires.
 #
@@ -270,6 +277,15 @@ want retries_a_transient_server_error_before_answering \
 start_stub --mode ok --body "$tmp/index-regex-trap.txt"
 want matches_the_version_literally_rather_than_as_a_regex \
   "$NOT_PUBLISHED" index_has "$stub_base" data-gov-ckan 0.5.0
+
+# A 200 whose body is not this crate's index file answers no question about
+# the crate. Reading it as "absent" would be reading it as an instruction to
+# publish, on the one path that cannot be taken back.
+start_stub --mode ok --body "$tmp/index-interception.txt"
+want reports_unknown_when_a_200_body_is_not_the_index_file \
+  "$UNKNOWN" index_has "$stub_base" data-gov-ckan 0.5.0
+and_output_has reports_unknown_when_a_200_body_is_not_the_index_file_and_says_so \
+  "with a body that is not the index file"
 
 echo "== publish-crate.sh =="
 

--- a/scripts/release/test-release-helpers.sh
+++ b/scripts/release/test-release-helpers.sh
@@ -12,6 +12,10 @@
 # that cannot be reached must stop the publish, never wave it through.
 #
 # Usage: test-release-helpers.sh [name-substring]
+#
+# The substring selects runs. A run's follow-up assertions come with it,
+# whether or not their own names match, because they have nothing to read
+# without it.
 
 set -uo pipefail
 
@@ -28,6 +32,15 @@ stub_pid=""
 stub_base=""
 passed=0
 failed=0
+skipped=0
+
+# Every `and_*` assertion reads the capture that the most recent `want` left
+# behind, so the filter decides once, at the `want`, and the assertions after
+# it inherit that decision. An assertion admitted by a filter that excluded
+# its own run would otherwise read whatever capture happened to be on disk -
+# some earlier case's, or none - and report a pass on another test's evidence.
+last_want_name=""
+last_want_ran=0
 
 stop_stub() {
   if [ -n "$stub_pid" ]; then
@@ -75,9 +88,12 @@ unreachable_base() {
 want() {
   local name="$1" expected="$2"
   shift 2
+  last_want_name="$name"
+  last_want_ran=0
   if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
     return 0
   fi
+  last_want_ran=1
   : > "$tmp/cargo.log"
   local actual=0
   "$@" > "$tmp/out" 2>&1 || actual=$?
@@ -91,13 +107,35 @@ want() {
   fi
 }
 
+# True when the run an `and_*` is about to inspect actually happened. When it
+# did not, the assertion is refused and said to be refused, rather than run
+# against a capture belonging to some other case.
+inspects_the_last_run() {
+  local name="$1"
+  if [ "$last_want_ran" -eq 1 ]; then
+    return 0
+  fi
+  if [ -z "$last_want_name" ]; then
+    printf 'FAIL %s: nothing to inspect - no run came before it\n' "$name"
+    failed=$((failed + 1))
+    return 1
+  fi
+  skipped=$((skipped + 1))
+  # Only say so when the filter named this assertion. Then the operator asked
+  # for a check whose run was left behind, and silence would look like a pass.
+  # Otherwise the filter is simply doing its job, and a line per case is noise.
+  if [[ "$name" == *"$filter"* ]]; then
+    printf 'skip %s: the run it inspects (%s) is outside the filter %s\n' \
+      "$name" "$last_want_name" "$filter"
+  fi
+  return 1
+}
+
 # Assertions about the run `want` just made. Kept separate so one case can
 # check both the exit status and what the operator was told.
 and_output_has() {
   local name="$1" needle="$2"
-  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
-    return 0
-  fi
+  inspects_the_last_run "$name" || return 0
   if grep -qF -- "$needle" "$tmp/out"; then
     printf 'ok   %s\n' "$name"
     passed=$((passed + 1))
@@ -110,9 +148,7 @@ and_output_has() {
 
 and_probes_numbered() {
   local name="$1" expected="$2"
-  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
-    return 0
-  fi
+  inspects_the_last_run "$name" || return 0
   local actual
   actual="$(cat "$tmp/probe-count" 2>/dev/null)"
   actual="${actual:-0}"
@@ -128,9 +164,7 @@ and_probes_numbered() {
 
 and_cargo_ran() {
   local name="$1"
-  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
-    return 0
-  fi
+  inspects_the_last_run "$name" || return 0
   if [ -s "$tmp/cargo.log" ]; then
     printf 'ok   %s\n' "$name"
     passed=$((passed + 1))
@@ -142,9 +176,7 @@ and_cargo_ran() {
 
 and_cargo_did_not_run() {
   local name="$1"
-  if [ -n "$filter" ] && [[ "$name" != *"$filter"* ]]; then
-    return 0
-  fi
+  inspects_the_last_run "$name" || return 0
   if [ -s "$tmp/cargo.log" ]; then
     printf 'FAIL %s: cargo ran anyway: %s\n' "$name" "$(cat "$tmp/cargo.log")"
     failed=$((failed + 1))
@@ -180,8 +212,16 @@ BODY
 
 # Keep the retries and the polling short. The defaults are tuned for a real
 # release; a test must not spend minutes proving a guard fires.
+#
+# The per-probe timeout is capped for the same reason, and it is not
+# redundant: the unreachable-index cases point curl at 127.0.0.1:1, which
+# normally refuses at once, but a host that DROPs instead makes each of those
+# fifteen probes sit out the timeout. At the 20s default that is five minutes
+# added to `just check`; five seconds is already far longer than a loopback
+# needs.
 export CRATES_INDEX_ATTEMPTS=3
 export CRATES_INDEX_RETRY_DELAY=0
+export CRATES_INDEX_TIMEOUT=5
 export CRATES_WAIT_ATTEMPTS=3
 export CRATES_WAIT_DELAY=0
 
@@ -246,8 +286,13 @@ and_cargo_ran publish_runs_cargo_when_the_index_does_not_list_the_version_call
 want publish_refuses_when_the_index_state_is_unknown \
   1 publish_crate "$(unreachable_base)" data-gov-ckan 0.5.0
 and_cargo_did_not_run publish_refuses_when_the_index_state_is_unknown_no_cargo
+# The needle has to be a phrase only publish-crate.sh can produce. The capture
+# holds the whole subtree's stderr, and index-has.sh writes its own "the
+# crates.io index could not be reached" into it on the way past - so that
+# phrase is present whatever publish-crate.sh decides, and asserting on it
+# tests nothing about the script this case is named for.
 and_output_has publish_names_the_unknown_index_state_in_its_error \
-  "could not be reached"
+  "::error::refusing to publish data-gov-ckan 0.5.0"
 
 start_stub --mode server-error
 want publish_refuses_when_the_index_returns_a_server_error \
@@ -263,6 +308,8 @@ want wait_returns_once_the_version_appears \
 start_stub --mode missing
 want wait_fails_when_the_version_never_appears \
   1 wait_for_crate "$stub_base" data-gov-ckan 0.5.0
+and_output_has wait_names_a_missing_publish_rather_than_an_unreachable_index \
+  ": not yet visible. If crates.io is healthy, the publish may have failed silently"
 
 # The poll loop is already the retry, so letting the probe retry inside it
 # would multiply the wait ceiling by the probe's attempt count. The bound is
@@ -275,10 +322,24 @@ and_probes_numbered wait_spends_one_probe_per_poll 3
 
 want wait_fails_when_the_index_stays_unreachable \
   1 wait_for_crate "$(unreachable_base)" data-gov-ckan 0.5.0
+# The two cases above are the two halves of one property: the final message
+# says which of "the version never appeared" and "the index never answered"
+# happened, because they call for different responses. Each needle is the
+# whole tail of that message, state and advice together, so collapsing either
+# branch into the other fails one of them.
+#
+# "could not be reached" on its own cannot do that job. index-has.sh runs
+# inside the poll loop and prints its own copy of that phrase on every poll,
+# into the same captured stream, so the needle is satisfied no matter what
+# wait-for-crate.sh concludes.
 and_output_has wait_names_the_unreachable_index_rather_than_a_missing_publish \
-  "could not be reached"
+  ": the index could not be reached. The publish itself may well have succeeded"
 
 stop_stub
 echo
-echo "passed: ${passed}, failed: ${failed}"
+echo "passed: ${passed}, failed: ${failed}, skipped: ${skipped}"
+if [ -n "$filter" ] && [ "$((passed + failed))" -eq 0 ]; then
+  echo "no run matched the filter '${filter}'; nothing was checked." >&2
+  exit 1
+fi
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
Closes findings from the independent review of the 0.5.0 release-review fixes.

Gate green in the authoring worktree; the reviewer re-verified by mutation on a clean checkout.

Detail is in the commit body.