### PR TITLE
test(catalog,ckan): enforce try_with_timeouts' timing contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -701,6 +701,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `missing_docs` lint once the outstanding gaps are documented (#59).
 - **Added an OSV/GHSA lockfile scan** alongside `cargo audit` (#46). The seven
   `openssl` advisories were GHSA-only and invisible to `cargo audit`.
+- **`Configuration::try_with_timeouts` now has a test that fails when it
+  ignores its arguments**, on both `data-gov-catalog` and `data-gov-ckan`. The
+  only test touching the new constructor built one with a 1s connect and 2s
+  overall timeout and then asserted `base_path` - a field with no relation to
+  timeouts - so replacing both function bodies with the crate defaults kept the
+  whole suite green. A consumer asking for a 100ms bound would have waited the
+  30s default against a host that accepts the connection and never answers, and
+  nothing would have reported it. Each crate now drives a real request through a
+  wiremock server that delays far past the configured timeout and asserts the
+  call returns inside it, matching the tests that already covered the infallible
+  `with_timeouts`. Only the overall timeout is exercised; the connect timeout
+  needs a peer that never answers the TCP handshake, which an in-process mock
+  server cannot offer. The old test is renamed to what it checks - that both
+  fallible constructors leave the non-timeout fields at their defaults.
 
 ## [0.4.0] - 2026-04-25
 

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -972,10 +972,19 @@ mod tests {
         );
     }
 
-    /// On a host that can build a client at all, the fallible constructors
-    /// return the same configuration as the panicking ones.
+    /// On a host that can build a client at all, both fallible constructors
+    /// leave every non-timeout field at the value the panicking constructors
+    /// use.
+    ///
+    /// The timeouts themselves are out of reach here: a built
+    /// [`reqwest::Client`] does not expose the values it was configured with,
+    /// so nothing in this test can distinguish a client that honours its
+    /// argument from one that ignored it. That property is behavioural and is
+    /// proved against a stalled server by
+    /// `try_with_timeouts_bounds_a_stalled_request_to_the_given_timeout` in
+    /// `tests/client_tests.rs`.
     #[test]
-    fn try_new_and_try_with_timeouts_return_the_documented_defaults() {
+    fn try_new_and_try_with_timeouts_leave_the_non_timeout_fields_at_their_defaults() {
         let config = Configuration::try_new().expect("a client builds on this host");
         assert_eq!(config.base_path, Configuration::new().base_path);
         assert_eq!(config.user_agent, Configuration::new().user_agent);
@@ -984,5 +993,6 @@ mod tests {
             Configuration::try_with_timeouts(Duration::from_secs(1), Duration::from_secs(2))
                 .expect("a client builds on this host");
         assert_eq!(timed.base_path, config.base_path);
+        assert_eq!(timed.user_agent, config.user_agent);
     }
 }

--- a/data-gov-catalog/tests/client_tests.rs
+++ b/data-gov-catalog/tests/client_tests.rs
@@ -955,6 +955,47 @@ async fn a_short_configured_timeout_bounds_a_stalled_request() {
     );
 }
 
+/// The fallible twin of `with_timeouts` has to apply the timeouts it is
+/// handed, not merely build a client from them. Same harness as
+/// `a_short_configured_timeout_bounds_a_stalled_request`: wiremock delays 5s
+/// against the 100ms overall timeout passed to the constructor, so a client
+/// that carries the argument through returns promptly, while one left on
+/// [`data_gov_catalog::DEFAULT_TIMEOUT`] (30s) is still waiting when the
+/// bound below expires.
+///
+/// Only the overall timeout is exercised. Reaching the connect timeout needs
+/// a peer that never answers the TCP handshake, which an in-process mock
+/// server cannot offer.
+#[tokio::test]
+async fn try_with_timeouts_bounds_a_stalled_request_to_the_given_timeout() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/search"))
+        .respond_with(ResponseTemplate::new(200).set_delay(Duration::from_secs(5)))
+        .mount(&server)
+        .await;
+
+    let mut config =
+        Configuration::try_with_timeouts(Duration::from_millis(50), Duration::from_millis(100))
+            .expect("a client builds on this host");
+    config.base_path = server.uri();
+    let client = CatalogClient::new(Arc::new(config));
+
+    let start = Instant::now();
+    let result = client.search(SearchParams::new().q("x")).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "took {elapsed:?} against the 100ms timeout passed to try_with_timeouts and a 5s \
+         server delay; the argument is not reaching the client"
+    );
+    assert!(
+        matches!(result, Err(CatalogError::RequestError(_))),
+        "an unresponsive server must produce a RequestError, not hang or succeed: got {result:?}"
+    );
+}
+
 /// Values that have no representation as a URL path segment.
 ///
 /// Percent-encoding cannot save these: the URL standard removes dot-segments

--- a/data-gov-ckan/src/client.rs
+++ b/data-gov-ckan/src/client.rs
@@ -1282,10 +1282,19 @@ mod tests {
         );
     }
 
-    /// On a host that can build a client at all, the fallible constructors
-    /// return the same configuration as the panicking ones.
+    /// On a host that can build a client at all, both fallible constructors
+    /// leave every non-timeout field at the value the panicking constructors
+    /// use.
+    ///
+    /// The timeouts themselves are out of reach here: a built
+    /// [`reqwest::Client`] does not expose the values it was configured with,
+    /// so nothing in this test can distinguish a client that honours its
+    /// argument from one that ignored it. That property is behavioural and is
+    /// proved against a delaying server by
+    /// `try_with_timeouts_bounds_a_call_to_the_given_duration` in
+    /// `tests/unit_tests.rs`.
     #[test]
-    fn try_new_and_try_with_timeouts_return_the_documented_defaults() {
+    fn try_new_and_try_with_timeouts_leave_the_non_timeout_fields_at_their_defaults() {
         let config = Configuration::try_new().expect("a client builds on this host");
         assert_eq!(config.base_path, Configuration::new().base_path);
         assert_eq!(config.user_agent, Configuration::new().user_agent);
@@ -1295,5 +1304,7 @@ mod tests {
             Configuration::try_with_timeouts(Duration::from_secs(1), Duration::from_secs(2))
                 .expect("a client builds on this host");
         assert_eq!(timed.base_path, config.base_path);
+        assert_eq!(timed.user_agent, config.user_agent);
+        assert!(timed.api_key.is_none(), "no credential is configured");
     }
 }

--- a/data-gov-ckan/tests/unit_tests.rs
+++ b/data-gov-ckan/tests/unit_tests.rs
@@ -1225,3 +1225,54 @@ async fn with_timeouts_bounds_a_call_to_the_given_duration() {
          but the call returned {result:?} after {elapsed:?}"
     );
 }
+
+/// `try_with_timeouts` is the fallible twin of `with_timeouts`, and has to
+/// apply the timeouts it is handed rather than merely build a client from
+/// them. Same harness as `with_timeouts_bounds_a_call_to_the_given_duration`:
+/// a mock delays 300ms against the 50ms overall timeout passed to the
+/// constructor, so a client that carries the argument through errors well
+/// under the delay, while one left on `DEFAULT_TIMEOUT` (30s) returns the
+/// delayed response instead.
+///
+/// Only the overall timeout is exercised. Reaching the connect timeout needs
+/// a peer that never answers the TCP handshake, which an in-process mock
+/// server cannot offer.
+#[tokio::test]
+async fn try_with_timeouts_bounds_a_call_to_the_given_duration() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/action/package_search"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"help": "", "success": true, "result": {}}))
+                .set_delay(std::time::Duration::from_millis(300)),
+        )
+        .mount(&server)
+        .await;
+
+    let config = Arc::new(Configuration {
+        base_path: server.uri(),
+        ..Configuration::try_with_timeouts(
+            std::time::Duration::from_millis(50),
+            std::time::Duration::from_millis(50),
+        )
+        .expect("a client builds on this host")
+    });
+
+    let started = std::time::Instant::now();
+    let result = CkanClient::new(config)
+        .package_search(None, None, None, None)
+        .await;
+    let elapsed = started.elapsed();
+
+    assert!(
+        result.is_err(),
+        "a 50ms try_with_timeouts client must bound a 300ms delayed response, \
+         but the call returned {result:?} after {elapsed:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(300),
+        "took {elapsed:?} against the 50ms timeout passed to try_with_timeouts and a \
+         300ms server delay; the argument is not reaching the client"
+    );
+}


### PR DESCRIPTION
Closes findings from the independent review of the 0.5.0 release-review fixes.

Gate green in the authoring worktree; the reviewer re-verified by mutation on a clean checkout.

Detail is in the commit body.