### PR TITLE
fix(download): bound the pre-flight name lookup by the same stall setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client with specific timeouts.
 
 ### Fixed
+- **A download's pre-flight name lookup is bounded** (#136). `check_download_url`
+  resolved the download URL's host with a bare `tokio::net::lookup_host` and no
+  timeout, once per file and once more per redirect hop. The lookup runs outside
+  reqwest, so neither bound on the download client reached it: `read_timeout` is
+  a property of the response body and starts only once a request is in flight,
+  and `connect_timeout` wraps reqwest's own connector, which covers the guarded
+  resolver's lookup and not this separate pre-flight one. Until #131 the MCP
+  server's 900-second request timeout was the only thing that ever ended it, and
+  exempting downloads from that timeout - the right fix for #131, because it was
+  killing transfers that were progressing - left this lookup with nothing to end
+  it at all. Worked case: 100 distributions against a host whose name servers
+  black-hole the query is roughly 30s per `getaddrinfo` on a stock glibc
+  `resolv.conf`, two lookups per file, so about 100 minutes of one MCP request
+  holding a dispatch slot with nothing server-side ending it. The bound is
+  `download_timeout_secs`, the same value that bounds the connect and each read,
+  so one setting governs every wait a download can stall on rather than two of
+  three. Nothing here can cut off a transfer that is moving bytes: a lookup that
+  is not answering has no byte in flight yet. A lookup that ran out of time
+  reports separately from one that answered "no such host", so a silent name
+  server can be told from a bad URL. **Stated plainly: the bound frees the
+  download, not the thread** - `getaddrinfo` runs on the blocking pool and
+  cannot be cancelled portably, so the pool task runs on until the system
+  resolver gives up.
 - **The MCP request timeout no longer kills a download that is progressing**
   (#131). Every method ran inside a 900-second wall-clock bound that is not
   operator-tunable, `data_gov.downloadResources` among them, so a transfer that

--- a/data-gov-mcp-server/src/concurrency_tests.rs
+++ b/data-gov-mcp-server/src/concurrency_tests.rs
@@ -443,9 +443,11 @@ async fn a_protocol_method_that_outruns_the_timeout_is_a_server_error() {
 /// loaded machine cannot fail this. Without it the call is abandoned, because
 /// the response cannot arrive before the budget expires.
 ///
-/// What still stops a download is unchanged and untested here: reqwest's
-/// `read_timeout` on the download client, which fires when no byte arrives for
-/// `download_timeout_secs`, and `notifications/cancelled`.
+/// What still stops a download is untested here: reqwest's `read_timeout` on
+/// the download client, which fires when no byte arrives for
+/// `download_timeout_secs`; the bound on the pre-flight name lookup, set from
+/// the same value and proved in `data_gov::util`; and
+/// `notifications/cancelled`.
 #[tokio::test]
 async fn a_progressing_download_outlives_the_wall_clock_budget() {
     /// Shorter than the transfer, so a bounded download cannot survive it.

--- a/data-gov-mcp-server/src/handlers.rs
+++ b/data-gov-mcp-server/src/handlers.rs
@@ -78,7 +78,9 @@ impl DataGovMcpServer {
     /// A tool the registry marks [`WallClockBound::Exempt`] runs without it.
     /// Elapsed time says nothing true about a transfer, so a budget that fits
     /// one link kills a healthy download on a slower one; what still stops
-    /// such a tool is its own stall bound and `notifications/cancelled`. The
+    /// such a tool is its own stall bounds - for a download, reqwest's
+    /// `read_timeout` and the bound on the pre-flight name lookup, which runs
+    /// outside reqwest - and `notifications/cancelled`. The
     /// answer is read from the tool registry rather than matched on the method
     /// name here, so a tool added later has to declare it - see
     /// [`crate::tools::ToolSpec::wall_clock`].

--- a/data-gov-mcp-server/src/server.rs
+++ b/data-gov-mcp-server/src/server.rs
@@ -33,8 +33,12 @@ pub(crate) const CANCELLED_NOTIFICATION: &str = "notifications/cancelled";
 /// request killed while it was working. It is not a download budget: a
 /// transfer's honest runtime is the size of a file over the width of a link,
 /// which no constant here can predict, so downloads are exempt and are bounded
-/// instead by reqwest's `read_timeout` on the download client - which restarts
-/// on every frame that arrives - and by `notifications/cancelled`.
+/// instead by the stall bounds inside the transfer itself and by
+/// `notifications/cancelled`. There are two stall bounds, both set from
+/// `download_timeout_secs`: reqwest's `read_timeout` on the download client,
+/// whose timer restarts on every frame that arrives, and a bound on the
+/// pre-flight name lookup, which runs outside reqwest and so is reached by
+/// neither `read_timeout` nor `connect_timeout`.
 pub(crate) const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(900);
 
 /// Responses buffered between the dispatch tasks and the writer.
@@ -62,8 +66,8 @@ const RESPONSE_QUEUE_DEPTH: usize = 64;
 /// cancellation cannot be read without reading the line in front of it - and
 /// [`DEFAULT_REQUEST_TIMEOUT`] is the backstop that frees the slot of every
 /// request it bounds. A download is deliberately not one of them: its slot is
-/// given up when the transfer finishes, when its own stall bound fires, or on
-/// a cancellation, never on elapsed time.
+/// given up when the transfer finishes, when one of its own stall bounds
+/// fires, or on a cancellation, never on elapsed time.
 const MAX_CONCURRENT_DISPATCHES: usize = 256;
 
 /// The largest message the server will accept, in bytes, newline included.

--- a/data-gov-mcp-server/src/tools.rs
+++ b/data-gov-mcp-server/src/tools.rs
@@ -20,10 +20,11 @@ pub(crate) enum WallClockBound {
     ///
     /// Only for a tool that streams bulk bytes, where progress rather than
     /// elapsed time says whether it is healthy. Such a tool must carry its own
-    /// stall bound - for downloads, reqwest's `read_timeout`, which restarts
+    /// stall bounds - for downloads, reqwest's `read_timeout`, which restarts
     /// on every frame that arrives and therefore kills a dead connection
-    /// without touching a live slow one - and must remain stoppable by
-    /// `notifications/cancelled`.
+    /// without touching a live slow one, and the bound on the pre-flight name
+    /// lookup, which runs outside reqwest and would otherwise reach no timer
+    /// at all - and must remain stoppable by `notifications/cancelled`.
     Exempt,
 }
 
@@ -305,9 +306,11 @@ pub(crate) static TOOL_SPECS: LazyLock<Vec<ToolSpec>> = LazyLock::new(|| {
             }),
             // The one exempt tool. Its runtime is the size of a file over
             // the width of a link, so no wall-clock figure can tell a healthy
-            // transfer from a stuck one. reqwest's `read_timeout` on the
-            // download client can, and `notifications/cancelled` is how a
-            // host asks for one to stop.
+            // transfer from a stuck one. Two bounds inside the transfer can:
+            // reqwest's `read_timeout` on the download client, and the same
+            // `download_timeout_secs` on the pre-flight name lookup, which
+            // runs outside reqwest. `notifications/cancelled` is how a host
+            // asks for one to stop.
             wall_clock: WallClockBound::Exempt,
         },
     ]

--- a/data-gov/Cargo.toml
+++ b/data-gov/Cargo.toml
@@ -52,7 +52,10 @@ toml = { version = "1.1.4", default-features = false, features = ["std", "serde"
 
 [dev-dependencies]
 wiremock = "0.6"
-tokio = { version = "1", features = ["full"] }
+# `test-util` is what lets a test pause the clock. The pre-flight name lookup
+# bound in src/util.rs is proved against a paused clock, so the outcome is
+# decided by which timer is nearer and never by how loaded the machine is.
+tokio = { version = "1", features = ["full", "test-util"] }
 serde_json = "1.0"
 tempfile = "3"
 # Process-level CLI tests (tests/cli_process_tests.rs): drives the real

--- a/data-gov/src/client.rs
+++ b/data-gov/src/client.rs
@@ -14,6 +14,7 @@ use futures::StreamExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::fs::File;
 use tokio::io::AsyncWriteExt;
 use url::Url;
@@ -55,6 +56,10 @@ struct DownloadJob<'a> {
     resource_name: Option<String>,
     dataset_name: Option<String>,
     allow_private_network: bool,
+    /// Bound on the pre-flight name lookup of the URL and of every redirect
+    /// hop, from [`DataGovClient::stall_bound`]. The lookup runs outside
+    /// reqwest, so no bound on the HTTP client reaches it.
+    lookup_timeout: Duration,
 }
 
 /// Owns the temporary file of a transfer in progress and removes it on drop.
@@ -140,9 +145,10 @@ impl DataGovClient {
     ///
     /// Returns [`DataGovError::ConfigError`] when `max_concurrent_downloads`
     /// or `download_timeout_secs` is zero. Neither zero has a useful meaning:
-    /// a zero-permit semaphore never closes (#73), and a zero-second
-    /// connect/read timeout fails every download immediately, in a way that
-    /// reads as a network problem rather than a configuration one (#107).
+    /// a zero-permit semaphore never closes (#73), and a zero-second stall
+    /// bound fails every download immediately - at the name lookup, before a
+    /// connection is even attempted - in a way that reads as a network problem
+    /// rather than a configuration one (#107).
     ///
     /// Every route to a configuration ends here, and none of them clamps on
     /// the way. The fields are `pub` on a struct that is not
@@ -169,17 +175,14 @@ impl DataGovClient {
         if config.download_timeout_secs == 0 {
             return Err(DataGovError::config_error(
                 "download_timeout_secs must be at least 1, got 0 (a zero-second \
-                 connect/read timeout would fail every download immediately)",
+                 lookup/connect/read timeout would fail every download immediately)",
             ));
         }
 
         let catalog = CatalogClient::new(config.catalog_config.clone());
 
         let allow_private = config.allow_private_network_downloads;
-        // A stall timeout, not a deadline on the transfer. `timeout` runs from
-        // the start of the connect until the body has finished, which caps how
-        // large a file can be fetched rather than how long it may hang.
-        let stall = std::time::Duration::from_secs(config.download_timeout_secs);
+        let stall = Self::stall_bound(&config);
         let http_client = reqwest::Client::builder()
             .connect_timeout(stall)
             .read_timeout(stall)
@@ -196,6 +199,20 @@ impl DataGovClient {
             config,
             http_client,
         })
+    }
+
+    /// How long a download may go without progress before it is abandoned.
+    ///
+    /// A stall bound, not a deadline on the transfer: a whole-request timeout
+    /// would run from the start of the connect until the body had finished,
+    /// which caps how large a file can be fetched rather than how long it may
+    /// hang. One value bounds all three places a download can stop making
+    /// progress - the connect, each read of the response body, and the
+    /// pre-flight name lookup - so an operator who raises
+    /// `download_timeout_secs` for a slow or distant link moves every one of
+    /// them rather than two.
+    fn stall_bound(config: &DataGovConfig) -> Duration {
+        Duration::from_secs(config.download_timeout_secs)
     }
 
     // === Search and Discovery ===
@@ -539,6 +556,7 @@ impl DataGovClient {
                 resource_name: distribution.title.clone(),
                 dataset_name: None,
                 allow_private_network: self.config.allow_private_network_downloads,
+                lookup_timeout: Self::stall_bound(&self.config),
             },
             self.reporter(),
         )
@@ -590,6 +608,7 @@ impl DataGovClient {
 
         let status_reporter = self.reporter();
         let allow_private_network = self.config.allow_private_network_downloads;
+        let lookup_timeout = Self::stall_bound(&self.config);
         let mut futures = Vec::with_capacity(distributions.len());
 
         for (index, distribution) in distributions.iter().enumerate() {
@@ -649,6 +668,7 @@ impl DataGovClient {
                         resource_name: distribution.title.clone(),
                         dataset_name: None,
                         allow_private_network,
+                        lookup_timeout,
                     },
                     status_reporter,
                 )
@@ -690,6 +710,7 @@ impl DataGovClient {
             resource_name,
             dataset_name,
             allow_private_network,
+            lookup_timeout,
         } = job;
 
         let notify_failure =
@@ -710,7 +731,8 @@ impl DataGovClient {
         // nothing behind. `fetch_checked` judges it again, which is one extra
         // lookup and deliberate: it has to be safe called on its own, rather
         // than safe because this caller happened to check first.
-        if let Err(err) = util::check_download_url(url, allow_private_network).await {
+        if let Err(err) = util::check_download_url(url, allow_private_network, lookup_timeout).await
+        {
             notify_failure(err.to_string(), &status_reporter);
             return Err(err);
         }
@@ -730,7 +752,14 @@ impl DataGovClient {
         // Every hop of the redirect chain goes through the same check the URL
         // above did, including the last one, and no request is made for a hop
         // that has not passed it.
-        let response = match util::fetch_checked(http_client, url, allow_private_network).await {
+        let response = match util::fetch_checked(
+            http_client,
+            url,
+            allow_private_network,
+            lookup_timeout,
+        )
+        .await
+        {
             Ok(resp) => resp,
             Err(err) => {
                 notify_failure(err.to_string(), &status_reporter);
@@ -1244,6 +1273,28 @@ mod tests {
         }
     }
 
+    /// One setting has to reach every bound a download can stall against.
+    ///
+    /// `with_config` builds the connect and read timeouts from
+    /// [`DataGovClient::stall_bound`], and every [`DownloadJob`] takes its
+    /// pre-flight lookup bound from the same call, so this is what pins the
+    /// value to the setting an operator actually sets. A constant creeping in
+    /// anywhere would leave a bound they cannot move.
+    #[test]
+    fn the_stall_bound_is_the_configured_download_timeout() {
+        for secs in [1u64, 42, 300, 86_400] {
+            let config = crate::config::DataGovConfig {
+                download_timeout_secs: secs,
+                ..crate::config::DataGovConfig::default()
+            };
+            assert_eq!(
+                DataGovClient::stall_bound(&config),
+                Duration::from_secs(secs),
+                "the stall bound must be download_timeout_secs, not a constant"
+            );
+        }
+    }
+
     // === #107: with_config rejects the zero values a struct literal or a
     // clamp-free builder path can produce ===
 
@@ -1254,7 +1305,7 @@ mod tests {
             ..crate::config::DataGovConfig::default()
         };
         let err = DataGovClient::with_config(config)
-            .expect_err("a zero-second connect/read timeout must be rejected, not clamped");
+            .expect_err("a zero-second stall bound must be rejected, not clamped");
         match err {
             DataGovError::ConfigError { message } => {
                 assert!(

--- a/data-gov/src/config.rs
+++ b/data-gov/src/config.rs
@@ -94,9 +94,11 @@ pub struct DataGovConfig {
     /// How long a download may stall, in seconds.
     ///
     /// This is a stall timeout, not a deadline on the whole transfer. It caps
-    /// the connect phase, and it caps the wait for each read of the response
+    /// three waits: the pre-flight name lookup of the download URL and of
+    /// every redirect hop, the connect phase, and each read of the response
     /// body, resetting after every successful read. A large file that arrives
-    /// slowly but steadily is not cut off; a connection that stops sending is.
+    /// slowly but steadily is not cut off; a connection that stops sending is,
+    /// and so is a name server that accepts the query and never answers.
     pub download_timeout_secs: u64,
     /// Permit downloads whose destination is on a private network.
     ///

--- a/data-gov/src/config/resolve.rs
+++ b/data-gov/src/config/resolve.rs
@@ -588,8 +588,8 @@ impl ConfigResolver {
             return Ok((defaults.download_timeout_secs, SettingSource::Default));
         };
 
-        // A zero stall timeout fails every download at the first read, with no
-        // explanation (#107).
+        // A zero stall bound fails every download at the name lookup, before a
+        // connection is even attempted, with no explanation (#107).
         if secs == 0 {
             return Err(at_least_one(key, source));
         }

--- a/data-gov/src/util.rs
+++ b/data-gov/src/util.rs
@@ -7,8 +7,10 @@
 
 use std::error::Error as StdError;
 use std::fmt;
+use std::future::Future;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Component, Path};
+use std::time::Duration;
 
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use url::{Host, Url};
@@ -244,11 +246,14 @@ pub(crate) fn check_url_without_dns(
 
 /// Check a download URL before the request leaves.
 ///
+/// `lookup_timeout` bounds the name lookup; see [`check_download_url_with`].
+///
 /// # Errors
 ///
 /// Returns [`DataGovError::ValidationError`] when the URL does not parse, uses
-/// a scheme other than `http` or `https`, names no host, cannot be resolved,
-/// or points at an address downloads may not reach.
+/// a scheme other than `http` or `https`, names no host, is not resolved
+/// within `lookup_timeout`, cannot be resolved at all, or points at an address
+/// downloads may not reach.
 ///
 /// # A limit worth stating
 ///
@@ -257,7 +262,68 @@ pub(crate) fn check_url_without_dns(
 /// differently - the DNS-rebinding case. [`GuardedResolver`] narrows that
 /// window by checking the addresses reqwest actually connects to, but a client
 /// at this layer cannot close it.
-pub(crate) async fn check_download_url(raw: &str, allow_private: bool) -> Result<()> {
+pub(crate) async fn check_download_url(
+    raw: &str,
+    allow_private: bool,
+    lookup_timeout: Duration,
+) -> Result<()> {
+    check_download_url_with(raw, allow_private, lookup_timeout, |host, port| {
+        tokio::net::lookup_host((host, port))
+    })
+    .await
+}
+
+/// The body of [`check_download_url`], with the name lookup supplied.
+///
+/// Taking the lookup as an argument is what makes the bound testable: a test
+/// drives a lookup that answers late, or not at all, without a name server and
+/// without depending on how long anything really takes.
+///
+/// # Why the lookup needs a bound of its own
+///
+/// This runs outside reqwest, so neither of the download client's bounds
+/// reaches it. `read_timeout` is a property of the response body, so it starts
+/// only once a request is in flight, and `connect_timeout` wraps reqwest's own
+/// connector, which covers the lookup [`GuardedResolver`] does and not this
+/// one. A name server that accepts a query and never answers therefore had
+/// nothing to end it. Cutting it off does not contradict the rule that work
+/// which is progressing is never killed on elapsed time: a lookup that is not
+/// answering is not progressing, and no byte of any transfer is in flight yet.
+///
+/// # Why the bound is passed rather than derived
+///
+/// The value is the download's own stall bound, `download_timeout_secs`, which
+/// already bounds the connect and each read of the body. One setting has to
+/// govern all three. Deriving a constant here would give an operator who
+/// raises the setting for a slow or distant link two thirds of what they asked
+/// for, and a third bound they can neither see nor change.
+///
+/// # A limit worth stating
+///
+/// The bound frees the caller, not the thread. `tokio::net::lookup_host` runs
+/// `getaddrinfo` on the blocking pool, and that call cannot be cancelled
+/// portably, so the pool task runs on until the system resolver gives up. What
+/// this ends is the download - and, above it, the MCP request - waiting on it.
+///
+/// # Errors
+///
+/// Returns [`DataGovError::ValidationError`] when the URL does not parse, uses
+/// a scheme other than `http` or `https`, names no host, is not resolved
+/// within `lookup_timeout`, cannot be resolved at all, or points at an address
+/// downloads may not reach. A lookup that ran out of time is reported
+/// separately from one that answered "no such host", so an operator can tell a
+/// silent name server from a name that does not exist.
+async fn check_download_url_with<L, F, I>(
+    raw: &str,
+    allow_private: bool,
+    lookup_timeout: Duration,
+    lookup: L,
+) -> Result<()>
+where
+    L: FnOnce(String, u16) -> F,
+    F: Future<Output = std::io::Result<I>>,
+    I: Iterator<Item = SocketAddr>,
+{
     let url = Url::parse(raw).map_err(|err| {
         DataGovError::validation_error(format!("download URL `{raw}` does not parse: {err}"))
     })?;
@@ -269,13 +335,20 @@ pub(crate) async fn check_download_url(raw: &str, allow_private: bool) -> Result
     };
 
     let port = url.port_or_known_default().unwrap_or(80);
-    let resolved = tokio::net::lookup_host((host.as_str(), port))
-        .await
-        .map_err(|err| {
-            DataGovError::validation_error(format!(
+    let resolved = match tokio::time::timeout(lookup_timeout, lookup(host.clone(), port)).await {
+        Err(_elapsed) => {
+            return Err(DataGovError::validation_error(format!(
+                "download URL host `{host}` did not resolve within {lookup_timeout:?}: \
+                 the name lookup timed out"
+            )));
+        }
+        Ok(Err(err)) => {
+            return Err(DataGovError::validation_error(format!(
                 "download URL host `{host}` does not resolve: {err}"
-            ))
-        })?;
+            )));
+        }
+        Ok(Ok(addresses)) => addresses,
+    };
 
     for address in resolved {
         if let Some(message) = address_refusal(&host, address.ip(), allow_private) {
@@ -313,6 +386,9 @@ pub(crate) async fn check_download_url(raw: &str, allow_private: bool) -> Result
 /// [`MAX_REDIRECT_HOPS`], and [`DataGovError::HttpError`] when a request fails
 /// for a transport reason.
 ///
+/// `lookup_timeout` is forwarded to [`check_download_url`] and so bounds the
+/// name lookup of every hop, not only the first.
+///
 /// # A limit worth stating
 ///
 /// This closes the case where a redirect to a name was followed with nothing
@@ -326,6 +402,7 @@ pub(crate) async fn fetch_checked(
     http_client: &reqwest::Client,
     url: &str,
     allow_private: bool,
+    lookup_timeout: Duration,
 ) -> Result<reqwest::Response> {
     let mut target = Url::parse(url).map_err(|err| {
         DataGovError::validation_error(format!("download URL `{url}` does not parse: {err}"))
@@ -333,7 +410,7 @@ pub(crate) async fn fetch_checked(
     let mut hops = 0usize;
 
     loop {
-        check_download_url(target.as_str(), allow_private).await?;
+        check_download_url(target.as_str(), allow_private, lookup_timeout).await?;
 
         let response =
             http_client
@@ -554,6 +631,9 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
+    /// A lookup bound no test means to reach.
+    const GENEROUS: Duration = Duration::from_secs(300);
+
     /// Every address here is drawn from the RFC that reserves the range, not
     /// from the implementation: RFC 1918 (private), RFC 3927 and RFC 4291
     /// (link-local), RFC 6598 (carrier-grade NAT), RFC 4193 (unique-local).
@@ -695,7 +775,7 @@ mod tests {
 
     #[tokio::test]
     async fn check_download_url_refuses_a_name_that_resolves_to_loopback() {
-        let error = check_download_url("http://localhost/data.csv", false)
+        let error = check_download_url("http://localhost/data.csv", false, GENEROUS)
             .await
             .expect_err("localhost resolves to loopback and must be refused");
         assert!(error.to_string().contains("localhost"), "got: {error}");
@@ -703,10 +783,190 @@ mod tests {
 
     #[tokio::test]
     async fn check_download_url_rejects_text_that_is_not_a_url() {
-        let error = check_download_url("not a url", false)
+        let error = check_download_url("not a url", false, GENEROUS)
             .await
             .expect_err("unparseable text must be refused");
         assert!(matches!(error, DataGovError::ValidationError { .. }));
+    }
+
+    /// A name lookup that answers after `delay`, standing in for a real one.
+    ///
+    /// The delay is a `tokio::time::sleep`, so under a paused clock it costs no
+    /// real time and the outcome is decided by which of the two timers - this
+    /// one or the bound - is nearer, never by how loaded the machine is.
+    async fn lookup_answering_after(
+        delay: Duration,
+        address: &str,
+    ) -> std::io::Result<std::vec::IntoIter<SocketAddr>> {
+        let address: SocketAddr = address.parse().expect("the test address must parse");
+        tokio::time::sleep(delay).await;
+        Ok(vec![address].into_iter())
+    }
+
+    /// A name lookup that fails the way an absent name does.
+    async fn lookup_failing_with_no_such_host() -> std::io::Result<std::vec::IntoIter<SocketAddr>> {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "no such host",
+        ))
+    }
+
+    /// A name lookup that must never be reached.
+    async fn lookup_that_must_not_run() -> std::io::Result<std::vec::IntoIter<SocketAddr>> {
+        panic!("this URL must be judged without a lookup");
+    }
+
+    /// The bound exists so a name server that never answers cannot hold a
+    /// download open. Without it nothing in the download path ends this wait:
+    /// the lookup runs outside reqwest, so `connect_timeout` and `read_timeout`
+    /// both miss it.
+    #[tokio::test(start_paused = true)]
+    async fn a_lookup_that_outlasts_the_bound_is_cut_off() {
+        let error = check_download_url_with(
+            "http://silent.example/data.csv",
+            false,
+            Duration::from_secs(5),
+            |_host, _port| lookup_answering_after(Duration::from_secs(3600), "93.184.216.34:80"),
+        )
+        .await
+        .expect_err("a lookup that outlasts the bound must be cut off");
+
+        let message = error.to_string();
+        assert!(
+            message.contains("silent.example"),
+            "the refusal must name the host an operator has to go and look at, got: {message}"
+        );
+        assert!(
+            message.contains("timed out"),
+            "a lookup that ran out of time must say so, got: {message}"
+        );
+    }
+
+    /// The bound that decides has to be the configured one, not a constant.
+    ///
+    /// The same lookup is driven twice and only the bound differs, so nothing
+    /// but the configured value can account for the two outcomes. The quoted
+    /// figure is checked too: an operator reading the message has to be able to
+    /// tell which setting cut the lookup off.
+    #[tokio::test(start_paused = true)]
+    async fn the_configured_bound_is_the_one_that_decides() {
+        const LOOKUP_TAKES: Duration = Duration::from_secs(30);
+
+        let cut_off = check_download_url_with(
+            "http://slow.example/data.csv",
+            false,
+            Duration::from_secs(5),
+            |_host, _port| lookup_answering_after(LOOKUP_TAKES, "93.184.216.34:80"),
+        )
+        .await
+        .expect_err("a five second bound is shorter than a thirty second lookup");
+        assert!(
+            cut_off.to_string().contains("5s"),
+            "the message must quote the bound that fired, got: {cut_off}"
+        );
+
+        check_download_url_with(
+            "http://slow.example/data.csv",
+            false,
+            Duration::from_secs(300),
+            |_host, _port| lookup_answering_after(LOOKUP_TAKES, "93.184.216.34:80"),
+        )
+        .await
+        .expect("a bound longer than the lookup must let the same lookup through");
+    }
+
+    /// A lookup that ran out of time and a name that does not exist are
+    /// different operational problems - a silent name server against a bad URL
+    /// - so the two messages have to be told apart without guessing.
+    #[tokio::test(start_paused = true)]
+    async fn a_lookup_that_times_out_reads_differently_from_one_that_fails() {
+        let timed_out = check_download_url_with(
+            "http://silent.example/data.csv",
+            false,
+            Duration::from_secs(5),
+            |_host, _port| lookup_answering_after(Duration::from_secs(3600), "93.184.216.34:80"),
+        )
+        .await
+        .expect_err("the lookup outlasts the bound")
+        .to_string();
+
+        let failed = check_download_url_with(
+            "http://absent.example/data.csv",
+            false,
+            GENEROUS,
+            |_host, _port| lookup_failing_with_no_such_host(),
+        )
+        .await
+        .expect_err("a lookup that fails is still a refusal")
+        .to_string();
+
+        assert!(timed_out.contains("timed out"), "got: {timed_out}");
+        assert!(failed.contains("does not resolve"), "got: {failed}");
+        assert!(
+            !failed.contains("timed out"),
+            "an NXDOMAIN must not read as a timeout, got: {failed}"
+        );
+    }
+
+    /// Bounding the lookup must not smuggle an address past the range check.
+    #[tokio::test(start_paused = true)]
+    async fn a_bounded_lookup_still_judges_the_address_it_gets() {
+        let error = check_download_url_with(
+            "http://mirror.example/data.csv",
+            false,
+            GENEROUS,
+            |_host, _port| lookup_answering_after(Duration::from_secs(1), "127.0.0.1:80"),
+        )
+        .await
+        .expect_err("an answer of loopback must still be refused");
+        assert!(error.to_string().contains("loopback"), "got: {error}");
+
+        check_download_url_with(
+            "http://mirror.example/data.csv",
+            false,
+            GENEROUS,
+            |_host, _port| lookup_answering_after(Duration::from_secs(1), "93.184.216.34:80"),
+        )
+        .await
+        .expect("a routable answer must pass");
+    }
+
+    /// The host and port the lookup is asked for are the ones the URL names,
+    /// including the port the scheme implies when the URL states none.
+    #[tokio::test(start_paused = true)]
+    async fn the_lookup_is_asked_for_the_host_and_port_the_url_names() {
+        for (url, expected_host, expected_port) in [
+            ("https://mirror.example/data.csv", "mirror.example", 443u16),
+            ("http://mirror.example/data.csv", "mirror.example", 80),
+            (
+                "http://mirror.example:8443/data.csv",
+                "mirror.example",
+                8443,
+            ),
+        ] {
+            check_download_url_with(url, false, GENEROUS, |host, port| {
+                assert_eq!(host, expected_host, "for {url}");
+                assert_eq!(port, expected_port, "for {url}");
+                lookup_answering_after(Duration::ZERO, "93.184.216.34:80")
+            })
+            .await
+            .expect("a routable answer must pass");
+        }
+    }
+
+    /// A literal address is judged without a lookup, so no bound applies to it.
+    /// A zero bound would cut off any lookup at all, which is what makes it the
+    /// proof that none was made.
+    #[tokio::test(start_paused = true)]
+    async fn a_literal_address_reaches_no_lookup_and_so_no_bound() {
+        check_download_url_with(
+            "http://93.184.216.34/data.csv",
+            false,
+            Duration::ZERO,
+            |_host, _port| lookup_that_must_not_run(),
+        )
+        .await
+        .expect("a routable literal address passes without resolving anything");
     }
 
     /// The resolver is the half of the check a synchronous redirect policy


### PR DESCRIPTION
Final round of the 0.5.0 release-review sweep. Mutation-proven and independently reviewed; the reviewer re-applied each mutation itself.

Detail in the commit body.