### PR TITLE
docs: correct three claims that were not true of the code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       run: just check-home-paths
       if: matrix.rust == 'stable'
 
-    - name: Check the CLI prints through the broken-pipe-safe macros
+    - name: Check for bare print macros in the CLI and the library crates
       run: just check-print-macros
       if: matrix.rust == 'stable'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -777,6 +777,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   needs a peer that never answers the TCP handshake, which an in-process mock
   server cannot offer. The old test is renamed to what it checks - that both
   fallible constructors leave the non-timeout fields at their defaults.
+- **Three doc comments that stated something untrue are corrected, and the
+  print-macro gate now describes the scope it actually scans.** The unit test
+  on the fallible constructors, in both client crates, said a built
+  `reqwest::Client` does not expose the timeouts it was configured with.
+  reqwest 0.13.4 prints the overall timeout in its `Debug` output, so an
+  assertion on it was possible all along; the real reason not to write one is
+  that the field name is `std::any::type_name` of a private reqwest type, which
+  nothing promises to keep stable. The docs now say that, and separate it from
+  the connect timeout, which genuinely never leaves the connector.
+  `DataGovConfig::get_base_download_dir` claimed its working-directory fallback
+  "never fails silently", which stopped being true when that line moved from
+  stderr to `tracing`: an embedder that installs no subscriber sees nothing. It
+  now says the report goes through `tracing` only and names the subscriber as
+  the way to receive it, agreeing with `data-gov/README.md`. `just
+  check-print-macros` and its CI step still called themselves CLI-only and
+  pointed at `outln!`/`errln!`, the wrong remedy for a library crate, where the
+  remedy is `tracing`; both now name the scopes the script scans and the two
+  remedies it prints.
+- **The renamed constructor test now checks every field its name claims.** On
+  `data-gov-ckan` it asserted `base_path`, `user_agent` and `api_key` while
+  claiming every non-timeout field, leaving `basic_auth`, `oauth_access_token`
+  and `bearer_access_token` unread. All four credential fields are asserted
+  now, so the only field of `Configuration` the test does not read is `client`,
+  which is where the timeouts live.
 
 ## [0.4.0] - 2026-04-25
 

--- a/data-gov-catalog/src/client.rs
+++ b/data-gov-catalog/src/client.rs
@@ -973,14 +973,20 @@ mod tests {
     }
 
     /// On a host that can build a client at all, both fallible constructors
-    /// leave every non-timeout field at the value the panicking constructors
-    /// use.
+    /// leave every field except `client` at the value the panicking
+    /// constructors use. `client` is exempt because it is the one field a
+    /// timeout is carried in.
     ///
-    /// The timeouts themselves are out of reach here: a built
-    /// [`reqwest::Client`] does not expose the values it was configured with,
-    /// so nothing in this test can distinguish a client that honours its
-    /// argument from one that ignored it. That property is behavioural and is
-    /// proved against a stalled server by
+    /// The timeouts themselves are not asserted on here, for two different
+    /// reasons. The connect timeout is held in the connector and never
+    /// appears in a built [`reqwest::Client`] at all. The overall timeout
+    /// does appear, in reqwest 0.13.4's `Debug` output, so an assertion could
+    /// read it -- but the field name there is whatever
+    /// [`std::any::type_name`] returns for a private reqwest type
+    /// (`reqwest::config::TotalTimeout` today), and neither std nor reqwest
+    /// promises anything about that string. A test that parsed it would be
+    /// pinned to an implementation detail that can change in a patch release.
+    /// The property is behavioural and is proved against a stalled server by
     /// `try_with_timeouts_bounds_a_stalled_request_to_the_given_timeout` in
     /// `tests/client_tests.rs`.
     #[test]

--- a/data-gov-ckan/src/client.rs
+++ b/data-gov-ckan/src/client.rs
@@ -1283,28 +1283,51 @@ mod tests {
     }
 
     /// On a host that can build a client at all, both fallible constructors
-    /// leave every non-timeout field at the value the panicking constructors
-    /// use.
+    /// leave every field except `client` at the value the panicking
+    /// constructors use. `client` is exempt because it is the one field a
+    /// timeout is carried in.
     ///
-    /// The timeouts themselves are out of reach here: a built
-    /// [`reqwest::Client`] does not expose the values it was configured with,
-    /// so nothing in this test can distinguish a client that honours its
-    /// argument from one that ignored it. That property is behavioural and is
-    /// proved against a delaying server by
+    /// The timeouts themselves are not asserted on here, for two different
+    /// reasons. The connect timeout is held in the connector and never
+    /// appears in a built [`reqwest::Client`] at all. The overall timeout
+    /// does appear, in reqwest 0.13.4's `Debug` output, so an assertion could
+    /// read it -- but the field name there is whatever
+    /// [`std::any::type_name`] returns for a private reqwest type
+    /// (`reqwest::config::TotalTimeout` today), and neither std nor reqwest
+    /// promises anything about that string. A test that parsed it would be
+    /// pinned to an implementation detail that can change in a patch release.
+    /// The property is behavioural and is proved against a delaying server by
     /// `try_with_timeouts_bounds_a_call_to_the_given_duration` in
     /// `tests/unit_tests.rs`.
     #[test]
     fn try_new_and_try_with_timeouts_leave_the_non_timeout_fields_at_their_defaults() {
+        // The four credential fields, none of which either constructor sets.
+        // They are checked together so no field of `Configuration` other than
+        // `client` goes unasserted.
+        fn assert_credentials_unset(config: &Configuration, which: &str) {
+            assert!(config.basic_auth.is_none(), "{which} set basic_auth");
+            assert!(
+                config.oauth_access_token.is_none(),
+                "{which} set oauth_access_token"
+            );
+            assert!(
+                config.bearer_access_token.is_none(),
+                "{which} set bearer_access_token"
+            );
+            assert!(config.api_key.is_none(), "{which} set api_key");
+        }
+
+        let panicking = Configuration::new();
         let config = Configuration::try_new().expect("a client builds on this host");
-        assert_eq!(config.base_path, Configuration::new().base_path);
-        assert_eq!(config.user_agent, Configuration::new().user_agent);
-        assert!(config.api_key.is_none(), "no credential is configured");
+        assert_eq!(config.base_path, panicking.base_path);
+        assert_eq!(config.user_agent, panicking.user_agent);
+        assert_credentials_unset(&config, "try_new");
 
         let timed =
             Configuration::try_with_timeouts(Duration::from_secs(1), Duration::from_secs(2))
                 .expect("a client builds on this host");
         assert_eq!(timed.base_path, config.base_path);
         assert_eq!(timed.user_agent, config.user_agent);
-        assert!(timed.api_key.is_none(), "no credential is configured");
+        assert_credentials_unset(&timed, "try_with_timeouts");
     }
 }

--- a/data-gov/src/config.rs
+++ b/data-gov/src/config.rs
@@ -199,11 +199,12 @@ impl DataGovConfig {
     /// folder in [`OperatingMode::Interactive`], the process working directory
     /// in [`OperatingMode::CommandLine`].
     ///
-    /// When the working directory cannot be read, this falls back to `"."` and
-    /// reports the reason as a `tracing` warning. It never fails silently
-    /// (#53). A download that names no directory of its own comes through
-    /// here, so the same warning can repeat: it goes somewhere an embedder
-    /// can filter, rather than onto a stderr the library does not own.
+    /// When the working directory cannot be read, this falls back to `"."`.
+    /// The fallback is always reported, through `tracing`, at `warn` (#53) --
+    /// and through `tracing` only, so install a subscriber to receive it. A
+    /// download that names no directory of its own comes through here, so the
+    /// same warning can repeat: it goes somewhere an embedder can route,
+    /// filter or silence, rather than onto a stderr the library does not own.
     pub fn get_base_download_dir(&self) -> PathBuf {
         if let Some(dir) = &self.base_download_dir {
             return dir.clone();

--- a/justfile
+++ b/justfile
@@ -51,9 +51,15 @@ check-home-paths:
     python3 scripts/check-home-paths.py --self-test
     python3 scripts/check-home-paths.py
 
-# Fail if the CLI prints with `println!`/`eprintln!`, which panic when the
-# reader closes the pipe (#115). `outln!`/`errln!` handle that; see
-# data-gov/tools/cli/ui/output.rs.
+# Fail if the CLI or a library crate prints with `println!`/`eprintln!`.
+#
+# Two defects, two remedies. In the CLI those macros panic when the reader
+# closes the pipe (#115); use `outln!`/`errln!`, see
+# data-gov/tools/cli/ui/output.rs. In data-gov, data-gov-catalog and
+# data-gov-ckan the line lands on a terminal the library does not own and an
+# embedder cannot route it; use `tracing`. The script prints the remedy for
+# the scope it fired on. data-gov-mcp-server is deliberately not scanned; the
+# script's own docstring says why.
 check-print-macros:
     python3 scripts/check-print-macros.py --self-test
     python3 scripts/check-print-macros.py


### PR DESCRIPTION
Final round of the 0.5.0 release-review sweep. Mutation-proven and independently reviewed; the reviewer re-applied each mutation itself.

Detail in the commit body.